### PR TITLE
Fix stop_on_error handling

### DIFF
--- a/usability/limit_output/main.js
+++ b/usability/limit_output/main.js
@@ -43,10 +43,10 @@ define([
     }
 
     cc.CodeCell.prototype._execute = cc.CodeCell.prototype.execute;
-    cc.CodeCell.prototype.execute = function(){
+    cc.CodeCell.prototype.execute = function(stop_on_error){
         // reset counter on execution.
         this.output_area.count = 0;
         this.output_area.drop  = false;
-        return this._execute();
+        return this._execute(stop_on_error);
     }
 });

--- a/usability/runtools/main.js
+++ b/usability/runtools/main.js
@@ -252,7 +252,7 @@ define([
         for (var i=0; i < IPython.notebook.ncells(); i++) {
             IPython.notebook.select(i);
             var cell = IPython.notebook.get_selected_cell();
-            cell.execute(stop_on_error=false);
+            cell.execute(false);
         }
     };
 


### PR DESCRIPTION
- fix calling `execute` in runtools
- add `stop_on_error` argument when overwriting `CodeCell.prototype.execute` in limit_output
