### PR TITLE
Updating all icons to be compliant with FontAwesome 4.3.0

### DIFF
--- a/publishing/gist_it.js
+++ b/publishing/gist_it.js
@@ -27,7 +27,7 @@ var cdict = {
 IPython.toolbar.add_buttons_group([
     {
              'label'   : 'Share Notebook',
-             'icon'    : 'ui-icon-info', 
+             'icon'    : 'fa-info-circle',
              'callback': function(){
                  IPython.notebook.kernel.execute(
                         //'!jist -p ' + IPython.notebook.notebook_name + '.ipynb',

--- a/publishing/nbconvert_button.js
+++ b/publishing/nbconvert_button.js
@@ -13,7 +13,7 @@ var do_nbconvert_extension = (function() {
         {
             id : 'doNbconvert',
             label : 'Convert current notebook to HTML',
-            icon : 'icon-download-alt',
+            icon : 'fa-download',
             callback : doNbconvert
         }
     ]);

--- a/publishing/printviewmenu_button.js
+++ b/publishing/printviewmenu_button.js
@@ -6,7 +6,7 @@ IPython.toolbar.add_buttons_group([
     {
         id : 'doPrintView',
         label : 'Create static print view',
-        icon : 'icon-print',
+        icon : 'fa-print',
         callback : function(){$('#print_preview').click();}
     }
 ]);

--- a/styling/zenmode/main.js
+++ b/styling/zenmode/main.js
@@ -89,7 +89,7 @@ define(function() {
       IPython.toolbar.add_buttons_group([
         {
         'label'   : 'Enter/Exit Zenmode',
-        'icon'    : 'icon-check-empty',
+        'icon'    : 'fa-check',
         'callback': function(){zenMode(param)},
         'id'      : 'start_zenmode'
         },

--- a/testing/hierarchical_collapse/main.js
+++ b/testing/hierarchical_collapse/main.js
@@ -501,7 +501,7 @@
         // Add a button to the toolbar
         IPython.toolbar.add_buttons_group([{
             label:'toggle heading',
-            icon:'icon-double-angle-up',
+            icon:'fa-angle-double-up',
             callback: function () {
                 var cell = find_toggleable_cell();
                 toggle_heading( cell );

--- a/testing/history/history.js
+++ b/testing/history/history.js
@@ -130,19 +130,19 @@ var init_history = function () {
                 {
                     id : 'forward',
                     label : 'Move cell history one step forward',
-                    icon : 'ui-icon-circle-plus',
+                    icon : 'fa-plus-circle',
                     callback : history_forward
                 },
                 {
                     id : 'back',
                     label : 'Move cell history one step back',
-                    icon : 'ui-icon-circle-minus',
+                    icon : 'fa-minus-circle',
                     callback : history_back
                 },
                 {
                     id : 'end',
                     label : 'All cells to latest step',
-                    icon : 'ui-icon-arrowstep-1-e',
+                    icon : 'fa-fast-forward',
                     callback : history_latest
                 },
             ]);

--- a/usability/aspell/ipy-aspell.js
+++ b/usability/aspell/ipy-aspell.js
@@ -99,13 +99,13 @@ spell_checker = function() {
         {
             id : 'doSpellCheck',
             label : 'Perform a spellcheck on cell',
-            icon : 'icon-check',
+            icon : 'fa-check',
             callback : doSpellCheck
         },
             {
             id : 'clearSpellCheck',
             label : 'Clear spellcheck markers',
-            icon : 'icon-trash',
+            icon : 'fa-trash',
             callback : clearSpellCheck
         }
 

--- a/usability/clean_start.js
+++ b/usability/clean_start.js
@@ -24,7 +24,7 @@ var confirm_dialog = function(){
 
 IPython.toolbar.add_buttons_group([{
       label:'clear all, and restart',
-      icon:'ui-icon-circle-triangle-w',
+      icon:'fa-chevron-circle-down',
       callback:confirm_dialog,
 }])
 console.log('loading clear and restart extension ok');

--- a/usability/help_panel/help_panel.js
+++ b/usability/help_panel/help_panel.js
@@ -76,7 +76,7 @@ var help_panel_extension = (function() {
             {
                 id : 'help_panel',
                 label : 'Show help panel',
-                icon : 'icon-book',
+                icon : 'fa-book',
                 callback : toggleHelpPanel
             }
       ]);

--- a/usability/hide_input/main.js
+++ b/usability/hide_input/main.js
@@ -25,7 +25,7 @@
         // Add a button to the toolbar
         IPython.toolbar.add_buttons_group([{
             label:'hide input',
-            icon:'icon-chevron-up',
+            icon:'fa-chevron-up',
             callback:hide_input,
         }]);
 

--- a/usability/hide_input_all.js
+++ b/usability/hide_input_all.js
@@ -24,7 +24,7 @@ var toggle_codecells_extension = (function() {
                 {
                     id : 'toggle_codecells',
                     label : 'Toggle codecell display',
-                    icon : 'icon-list-alt',
+                    icon : 'fa-bars',
                     callback : toggle
                 }
           ]);

--- a/usability/init_cell/main.js
+++ b/usability/init_cell/main.js
@@ -46,7 +46,7 @@ var add_run_init_button = function(){
     IPython.toolbar.add_buttons_group([
          {
               'label'   : 'run init_cell',
-              'icon'    : 'ui-icon-calculator', 
+              'icon'    : 'fa-calculator',
               'callback': run_init
          }
          ]);

--- a/usability/noscroll.js
+++ b/usability/noscroll.js
@@ -14,7 +14,7 @@ IPython.toolbar.add_buttons_group(
     [
        {
             'label'   : 'No auto-output scrolling (Definitive until restart/reload of the page)',
-            'icon'    : 'ui-icon-circlesmall-close',
+            'icon'    : 'fa-close',
             'callback': function() {
                 IPython.OutputArea.prototype._should_scroll = function (){return false}
             }

--- a/usability/read-only.js
+++ b/usability/read-only.js
@@ -81,7 +81,7 @@ var readonly_extension = (function() {
                 {
                     id : 'read_only_codecell',
                     label : 'Toggle read-only codecell',
-                    icon : 'icon-lock',
+                    icon : 'fa-lock',
                     callback : toggleReadOnly
                 }
           ]);

--- a/usability/toggle_all_line_number.js
+++ b/usability/toggle_all_line_number.js
@@ -11,6 +11,6 @@ var toggle_all = function(){
 
 IPython.toolbar.add_buttons_group([{
       label:'toggle all line number',
-      icon:'ui-icon-note',
+      icon:'fa-sort-numeric-asc',
       callback:toggle_all,
 }])


### PR DESCRIPTION
Many of the icons needed updating to be compliant with IPython's implementation of the FontAwesome 4.X.X series. Those that have not been updated simply show up as blank in the Notebook toolbar. I have gone through the code and updated all icons to the FA 4.3.0 series (the most recent), attempting to keep the graphical images as closely as intended by the original authors. This work done in response to Issue #187. I have verified that these icons work on a subset of all changes made.