### PR TITLE
Update nbextensions.py

### DIFF
--- a/config/nbextensions.py
+++ b/config/nbextensions.py
@@ -6,6 +6,7 @@ from IPython.utils.path import get_ipython_dir
 from IPython.html.utils import url_path_join as ujoin
 from IPython.html.base.handlers import IPythonHandler, json_errors
 from tornado import web
+from itertools import chain
 import os
 import yaml
 import json
@@ -15,11 +16,11 @@ class NBExtensionHandler(IPythonHandler):
     @web.authenticated
     def get(self):
         ipythondir = get_ipython_dir()        
-        nbextensions = os.path.join(ipythondir,'nbextensions') 
+        nbextensions = (IPython.html.nbextensions._get_nbext_dir(), os.path.join(ipythondir,'nbextensions'))
         exclude = [ 'mathjax' ]
         yaml_list = []
         # Traverse through nbextension subdirectories to find all yaml files
-        for root, dirs, files in os.walk(nbextensions):
+        for root, dirs, files in chain.from_iterable(os.walk(root) for root in nbextensions):
             dirs[:] = [d for d in dirs if d not in exclude]
             for f in files:
                 if f.endswith('.yaml'):


### PR DESCRIPTION
Account for extensions installed for all users in the jupyter/ipython shared directory.

Following the [3.x installation instructions](https://github.com/ipython-contrib/IPython-notebook-extensions/wiki/Home_3x), the install location is set to a shared location for all users in the python distribution directory hierarchy.  However, when loading the [config_extenstion](https://github.com/ipython-contrib/IPython-notebook-extensions/wiki/config-extension), it only looks in the user nbextensions directory hierarchy.  This PR will allow YAML files to be read from both locations.

There is no care taken for redundant extensions (e.g. same extension in both locations).

This was validated on:
* WinPython-64bit-3.4.3.3.
* Ubuntu 14.04 LTS python 3.4.0 ipython 3.1.0