### PR TITLE
Create international_keymap.js

### DIFF
--- a/usability/international_keymap.js
+++ b/usability/international_keymap.js
@@ -1,0 +1,50 @@
+"use strict";
+
+define(function(){
+  return {
+    // this will be called at extension loading time
+    //---
+    load_ipython_extension: function(){
+        console.log("I have been loaded ! -- international_keymap");
+    }
+    //---
+  };
+})
+
+
+var add_edit_shortcuts = {
+        'Alt-3' : {
+            help    : 'Toggle comments',
+            help_index : 'zz',
+            handler : function () {
+                var cm=IPython.notebook.get_selected_cell().code_mirror;
+                var from = cm.getCursor("start"), to = cm.getCursor("end");
+                cm.uncomment(from, to) || cm.lineComment(from, to);
+                return false;
+            }
+        },
+
+        'Alt-1' : {
+            help: 'Indent',
+            help_index : 'zz',
+            handler: function() {
+                var cm=IPython.notebook.get_selected_cell().code_mirror;
+                cm.execCommand('indentMore');
+                return false;
+            }
+        },
+
+        'Alt-2' : {
+            help    : 'indent less',
+            help_index : 'zz',
+            handler : function () {
+                var cm = IPython.notebook.get_selected_cell().code_mirror;
+                cm.execCommand('indentLess');
+                return false;
+            }
+        },
+    };
+
+IPython.keyboard_manager.edit_shortcuts.add_shortcuts(add_edit_shortcuts);
+IPython.keyboard_manager.command_shortcuts.add_shortcut('Shift-k','ipython.move-selected-cell-up')
+IPython.keyboard_manager.command_shortcuts.add_shortcut('Shift-j','ipython.move-selected-cell-down')

--- a/usability/international_keymap.js
+++ b/usability/international_keymap.js
@@ -1,50 +1,50 @@
-"use strict";
+define(['base/js/namespace'], function (IPython) {
+    "use strict";
+    var toggle_comments = {
+        help    : 'Toggle comments',
+        help_index : 'zz',
+        handler : function (env) {
+            var cm=env.notebook.get_selected_cell().code_mirror;
+            var from = cm.getCursor("start"), to = cm.getCursor("end");
+            cm.uncomment(from, to) || cm.lineComment(from, to);
+            return false;
+        }
+    };
 
-define(function(){
+    var indent_selection = {
+        help: 'Indent',
+        help_index : 'zz',
+        handler: function (env) {
+            var cm=env.notebook.get_selected_cell().code_mirror;
+            cm.execCommand('indentMore');
+            return false;
+        }
+    };
+
+    var dedent_selection = {
+        help    : 'Indent less',
+        help_index : 'zz',
+        handler : function (env) {
+            var cm = env.notebook.get_selected_cell().code_mirror;
+            cm.execCommand('indentLess');
+            return false;
+        }
+    };
+
   return {
     // this will be called at extension loading time
     //---
-    load_ipython_extension: function(){
-        console.log("I have been loaded ! -- international_keymap");
+    load_ipython_extension: function (){
+        IPython.keyboard_manager.actions.register(toggle_comments,'toggle_comments');
+        IPython.keyboard_manager.actions.register(indent_selection,'indent_selection');
+        IPython.keyboard_manager.actions.register(dedent_selection,'dedent_selection');
+        IPython.keyboard_manager.edit_shortcuts.add_shortcut('Alt-3', 'auto.toggle_comments');
+        IPython.keyboard_manager.edit_shortcuts.add_shortcut('Alt-2', 'auto.dedent_selection');
+        IPython.keyboard_manager.edit_shortcuts.add_shortcut('Alt-1', 'auto.indent_selection');
+        IPython.keyboard_manager.command_shortcuts.add_shortcut('Shift-k','ipython.move-selected-cell-up');
+        IPython.keyboard_manager.command_shortcuts.add_shortcut('Shift-j','ipython.move-selected-cell-down');
+        console.log("I have been loaded ! -- interantional_shortcuts");
     }
     //---
   };
-})
-
-
-var add_edit_shortcuts = {
-        'Alt-3' : {
-            help    : 'Toggle comments',
-            help_index : 'zz',
-            handler : function () {
-                var cm=IPython.notebook.get_selected_cell().code_mirror;
-                var from = cm.getCursor("start"), to = cm.getCursor("end");
-                cm.uncomment(from, to) || cm.lineComment(from, to);
-                return false;
-            }
-        },
-
-        'Alt-1' : {
-            help: 'Indent',
-            help_index : 'zz',
-            handler: function() {
-                var cm=IPython.notebook.get_selected_cell().code_mirror;
-                cm.execCommand('indentMore');
-                return false;
-            }
-        },
-
-        'Alt-2' : {
-            help    : 'indent less',
-            help_index : 'zz',
-            handler : function () {
-                var cm = IPython.notebook.get_selected_cell().code_mirror;
-                cm.execCommand('indentLess');
-                return false;
-            }
-        },
-    };
-
-IPython.keyboard_manager.edit_shortcuts.add_shortcuts(add_edit_shortcuts);
-IPython.keyboard_manager.command_shortcuts.add_shortcut('Shift-k','ipython.move-selected-cell-up')
-IPython.keyboard_manager.command_shortcuts.add_shortcut('Shift-j','ipython.move-selected-cell-down')
+});

--- a/usability/international_keymap.js
+++ b/usability/international_keymap.js
@@ -43,7 +43,7 @@ define(['base/js/namespace'], function (IPython) {
         IPython.keyboard_manager.edit_shortcuts.add_shortcut('Alt-1', 'auto.indent_selection');
         IPython.keyboard_manager.command_shortcuts.add_shortcut('Shift-k','ipython.move-selected-cell-up');
         IPython.keyboard_manager.command_shortcuts.add_shortcut('Shift-j','ipython.move-selected-cell-down');
-        console.log("I have been loaded ! -- interantional_shortcuts");
+        console.log("I have been loaded ! -- international_shortcuts");
     }
     //---
   };


### PR DESCRIPTION
Expanded the toggle-command extension to include the indent and dedent commands with keybindings, which will work better on non-US-keyboards.

I'm unsure about the name, and if further steps are required to make this fit in this repo.