### PR TITLE
Add parameter handling to config server extension

### DIFF
--- a/config/nbextensions.py
+++ b/config/nbextensions.py
@@ -47,7 +47,9 @@ class NBExtensionHandler(IPythonHandler):
                 url = y[0][idx::].replace('\\', '/')
                 extension['url'] = url
                 # replace single quote with HTML representation
-                extension['Description'] = extension['Description'].replace("'","&#39;")
+                for key in extension:
+                    if isinstance(extension[key], str):
+                        extension[key] = extension[key].replace("'","&#39;")
                 extension_list.append(extension)
                 self.log.info("Found extension %s" % extension['Name'])
             stream.close()


### PR DESCRIPTION
Add parameters to the extension:
If the YAML description of the notebook contains these entries:
`Parameter:`
`ParameterDescription:`
An input element is added to the extension configuration.

Also, make sure all strings used to compose the json list are checked for single quotes.