### PR TITLE
Update pymarkdown extension for 4.x

### DIFF
--- a/usability/python-markdown/main.js
+++ b/usability/python-markdown/main.js
@@ -14,7 +14,7 @@ define([
     'base/js/security',
     'components/marked/lib/marked',
     'base/js/events',
-	'notebook/js/textcell'
+    'notebook/js/textcell'
 ], function(IPython, $, cell, security, marked, events,textcell) {
     "use strict";
     if (IPython.version[0] < 3) {
@@ -133,19 +133,25 @@ define([
 		return original_render.apply(this)
 	};
 
-    events.on("rendered.MarkdownCell", function(event, data) {
-        render_cell(data.cell)
-    });
-	
-    /* show values stored in metadata on reload */
-    events.on("kernel_ready.Kernel", function() {
-        var ncells = IPython.notebook.ncells();
-        var cells = IPython.notebook.get_cells();
-        for (var i=0; i<ncells; i++) {
-            var cell=cells[i];
-            if ( cell.metadata.hasOwnProperty('variables')) { 
-                render_cell(cell)
+    var load_ipython_extension = function() {
+        events.on("rendered.MarkdownCell", function (event, data) {
+            render_cell(data.cell)
+        });
+
+        /* show values stored in metadata on reload */
+        events.on("kernel_ready.Kernel", function () {
+            var ncells = IPython.notebook.ncells();
+            var cells = IPython.notebook.get_cells();
+            for (var i = 0; i < ncells; i++) {
+                var cell = cells[i];
+                if (cell.metadata.hasOwnProperty('variables')) {
+                    render_cell(cell)
+                }
             }
-        }
-    })
+        });
+    };
+    var extension = {
+        load_ipython_extension : load_ipython_extension
+    };
+    return extension;
 });

--- a/usability/python-markdown/pymdpreprocessor.py
+++ b/usability/python-markdown/pymdpreprocessor.py
@@ -6,22 +6,15 @@ stored in cell metadata
 from nbconvert.preprocessors import *
 import re
 
-def get_variable( match, variables):
-    try:
-        x = variables[match]
-        return x
-    except KeyError:
-        return ""
-
 
 class PyMarkdownPreprocessor(Preprocessor):
     
-    def replace_variables(self,source,variables):
+    def replace_variables(self, source, variables):
         """
         Replace {{variablename}} with stored value
         """
         try:
-            replaced = re.sub("{{(.*?)}}", lambda m: get_variable(m.group(1),variables) , source)
+            replaced = re.sub("{{(.*?)}}", lambda m: variables.get(m.group(1), ''), source)
         except TypeError:
             replaced = source
         return replaced

--- a/usability/python-markdown/pymdpreprocessor.py
+++ b/usability/python-markdown/pymdpreprocessor.py
@@ -1,25 +1,27 @@
+# -*- coding: utf-8 -*-
 """This preprocessor replaces Python code in markdowncell with the result
 stored in cell metadata
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2014, Juergen Hasch
-#
-# Distributed under the terms of the Modified BSD License.
-#
-#-----------------------------------------------------------------------------
-
-from IPython.nbconvert.preprocessors import *
+from nbconvert.preprocessors import *
 import re
 
-class PyMarkdownPreprocessor(Preprocessor):
+def get_variable( match, variables):
+    try:
+        x = variables[match]
+        return x
+    except KeyError:
+        return ""
 
+
+class PyMarkdownPreprocessor(Preprocessor):
+    
     def replace_variables(self,source,variables):
         """
         Replace {{variablename}} with stored value
         """
         try:
-            replaced = re.sub("{{(.*?)}}", lambda m: variables[m.group(1)] , source)
+            replaced = re.sub("{{(.*?)}}", lambda m: get_variable(m.group(1),variables) , source)
         except TypeError:
             replaced = source
         return replaced

--- a/usability/python-markdown/python-markdown.yaml
+++ b/usability/python-markdown/python-markdown.yaml
@@ -5,4 +5,4 @@ Link: https://github.com/ipython-contrib/IPython-notebook-extensions/wiki/python
 Icon: python-markdown.png
 Main: main.js
 Preprocessor: pymdpreprocessor.py
-Compatibility: 3.x
+Compatibility: 4.x


### PR DESCRIPTION
* Export `ipython_load_extension`
* Use new `nbconvert` imports for preprocessor