### PR TITLE
Allow markdown docs in notebook extension configuration

### DIFF
--- a/config/main.js
+++ b/config/main.js
@@ -10,7 +10,7 @@ require([
     'base/js/page',
     'base/js/utils',
     'services/config',
-    "base/js/events",
+    "base/js/events"
 ], function(
     $,
     require,
@@ -282,14 +282,14 @@ require([
         var btn_activate = $('<button/>', {
             'type': 'button',
             'class': 'btn btn-primary',
-            'id': ext_id + '-on',
+            'id': ext_id + '-on'
         }).text('Activate').on('click', handle_buttons_click);
         btn_activate.appendTo(div_buttons);
 
         var btn_deactivate = $('<button/>', {
             'type': 'button',
             'class': 'btn btn-default',
-            'id': ext_id + '-off',
+            'id': ext_id + '-off'
         }).text('Deactivate').on('click', handle_buttons_click);
         btn_deactivate.appendTo(div_buttons);
 
@@ -364,7 +364,11 @@ require([
                     }
 
                     if (extension.Link !== undefined) {
-                        var link = $('<a>').attr('href', extension.Link).text('more...');
+                        var link = extension.Link;
+                        if (!/^(f|ht)tps?:\/\//i.test(link)) {
+                            link = base_url + 'rendermd/' + extension['url'] +'/' + link;
+                        }
+                        link = $('<a>').attr('href', link).text('more...');
                         link.appendTo(div_compat_and_desc);
                     }
 

--- a/config/nbextensions.html
+++ b/config/nbextensions.html
@@ -18,6 +18,7 @@ data-extension-list='{{extension_list}}'
 <div class="pull-left nbext-page-title-wrap">
 	<span class="nbext-page-title" style="display: none;">
 		Configuration for Notebook Extensions
+		(<a href="/rendermd/nbextensions/config/readme.md">more Information</a>)
 	</span>
 </div>
 <div class="nbext-showhide-incompat" style="display: none;">
@@ -42,5 +43,5 @@ data-extension-list='{{extension_list}}'
 
     {{super()}}
 
-<script src="{{ "/nbextensions/config/main.js" }}" type="text/javascript" charset="utf-8"></script>
+<script src="/nbextensions/config/main.js" type="text/javascript" charset="utf-8"></script>
 {% endblock %}

--- a/config/readme.md
+++ b/config/readme.md
@@ -1,0 +1,65 @@
+# Introduction
+
+The Jupyter notebook functionality (i.e. what you do with the Browser) can be extended using Javascript extensions.
+This page allows you to activate or deacivate installed notebook extensions, if they provide a `YAML` file description.
+
+Activating an extension means it is loaded automatically when working with a notebook document.
+ 
+If you encounter problems with this page, please create an issue at the [ipython-contrib](https://github.com/ipython-contrib/IPython-notebook-extensions) repository.
+
+## Checking/loading notebook extension manually from IPython
+You can check if the directory or a file (or list of files) exists:
+```Python
+import notebook
+notebook.nbextensions.check_nbextension('usability/codefolding', user=True)
+notebook.nbextensions.check_nbextension('usability/codefolding/main.js', user=True)
+```
+Make sure to use `user=True` if you have the extensions installed in your local path (in `jupyter_data_dir()`).
+
+To enable an extension:
+```Python
+import notebook
+E = notebook.nbextensions.EnableNBExtensionApp()
+E.enable_nbextension('usability/codefolding/main')
+```
+
+To disable an extension:
+```Python
+import notebook
+D = notebook.nbextensions.DisableNBExtensionApp()
+D.disable_nbextension('usability/codefolding/main')
+```
+The configuration is stored in either `jupyter_config_dir()/notebok.json` or `jupyter_config_dir()/nbconfig/notebook.json` 
+depending on your Jupyter (4.0.xx or master) version.
+
+If you reload the notebook after enabling a notebook extension, the extension will be loaded. You can check the Javascript console to confirm.
+
+
+# General extension installation instructions
+Installing and activating notebook extensions works differently in Jupyter compared to Python. Please be aware that Jupyter is still in development stage and some commands would change in future. 
+
+* There is a graphical interface for activating/deactivating notebook extensions now. You might want to use it:
+[config-extension](config-extension)
+
+##1. Installing an extension
+
+`jupyter nbextension install <name of extension>`
+
+Example:
+`jupyter nbextension install usability/codefolding/main`
+
+##2. Activating an extension
+
+`jupyter nbextension enable <name of extension>`
+
+##3. Deactivating extensions
+
+`jupyter nbextension disable <name of extension>`
+
+## Troubleshooting
+If the extension does not work, here is how you can check what is wrong:
+
+1. Clear your browser cache or start a private browser tab.
+2. Verify the extension can be loaded by the IPython notebook, for example:
+    `http://127.0.0.1:8888/nbextensions/IPython-notebook-extensions-master/usability/runtools/main.js`
+3. Check for error messages in the JavaScript console of the browser. 

--- a/config/render.js
+++ b/config/render.js
@@ -1,0 +1,34 @@
+// Copyright (c) IPython-Contrib Team.
+// Distributed under the terms of the Modified BSD License.
+
+// Render markdown url
+
+require([
+    'base/js/namespace',
+    'base/js/utils',
+    'base/js/page',
+    'jquery',
+    'require',
+    'components/marked/lib/marked'
+], function(
+    IPython,
+    utils,
+    page,
+    $, require,
+    marked
+    ){
+    page = new page.Page();
+
+    var base_url = utils.get_body_data('baseUrl');
+    var md_url = $('body').data('md-url');
+    /* build html body listing all extensions */
+    var html = "";
+    $("#nbextensions-container").html(html);
+
+    var url = base_url +  md_url;
+    $.get(url, function( my_var ) {
+        $("#render-container").html(marked(my_var));
+    }, 'text');  // or 'text', 'xml', 'more' */
+
+    page.show();
+});

--- a/config/rendermd.html
+++ b/config/rendermd.html
@@ -1,0 +1,37 @@
+{% extends "page.html" %}
+
+{% block title %}{{page_title}}{% endblock %}
+
+{% block stylesheet %}
+{{super()}}
+{% endblock %}
+
+{% block params %}
+
+data-base-url='{{base_url}}'
+data-md-url='{{render_url}}'
+
+{% endblock %}
+
+{% block headercontainer %}
+
+<center><h2>{{ page_title }}</h2></center>
+
+{% endblock %}
+
+{% block header %}
+
+{% endblock %}
+
+{% block site %}
+
+<div id="render-container" class="container"></div>
+
+{% endblock %}
+
+{% block script %}
+
+    {{super()}}
+
+<script src="{{ "/nbextensions/config/render.js" }}" type="text/javascript" charset="utf-8"></script>
+{% endblock %}


### PR DESCRIPTION
Replaces #272 

Allow extensions to supply a markdown readme file and render it using marked.js. 
Example url: `http://127.0.0.1:8888/rendermd/nbextensions/nbconfig/readme.md`
