### PR TITLE
gitignore potential mathjax files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 custom.js
 custom.css
+mathjax/*


### PR DESCRIPTION
mathjax can be stored in nbextensions for local serving when a network connections is not available to reach the CDN. We don't want to track anything that might be in the mathjax folder.