### PR TITLE
Fixing paths to latex_envs files. Also removing 'http:' prefix from f…

### DIFF
--- a/nbextensions/usability/latex_envs/bibInNb4.js
+++ b/nbextensions/usability/latex_envs/bibInNb4.js
@@ -1,11 +1,11 @@
 /*
-This file contains some functions used for bibliography formatting. 
+This file contains some functions used for bibliography formatting.
 The bibtex bibliography is read by `readBibliography` and parsed using
-the bibtex [bibtex-js](https://code.google.com/p/bibtex-js/) parser. 
-The bibliography object is stored  in document.bibliography. A reference 
-section is added at the end of the notebook. Citations are formated according 
-to the simple templates described in the object cit_tpl (see the file latex_envs_jup). 
-These templates can be customized. 
+the bibtex [bibtex-js](https://code.google.com/p/bibtex-js/) parser.
+The bibliography object is stored  in document.bibliography. A reference
+section is added at the end of the notebook. Citations are formated according
+to the simple templates described in the object cit_tpl (see the file latex_envs_jup).
+These templates can be customized.
 */
 
 if (typeof Jupyter == 'undefined'){var Jupyter=IPython;} //for IPython 3.x
@@ -13,24 +13,24 @@ document.bibliography={};
 var bibmsg="";
 
 function readBibliography(callback){
-require(["nbextensions/latex_envs/bibtex2"], function () {
-   	
+require(["nbextensions/usability/latex_envs/bibtex2"], function () {
+
 	document.bibliography={}; bibmsg="";
     document.bibtex_parser = new BibtexParser();
-    
+
     function parse_bibtex(string) {
         document.bibtex_parser.setInput(string);
         document.bibtex_parser.bibtex();
         // {KEY: {AUTHOR:..., BIB_KEY:...}}
         return document.bibtex_parser.getEntries();
     }
-    	
+
     $.get(bibliofile, function (data){
         var json = parse_bibtex(data)
-        $.extend(document.bibliography, json);   
+        $.extend(document.bibliography, json);
     }).fail(function () {bibmsg="The bib file "+bibliofile+" was not found\n\n"; console.log(bibmsg)})
 	.always(function (){if (typeof callback != "undefined") {callback()}})
-	
+
     })
 	return true
 }
@@ -77,20 +77,20 @@ function createReferenceSection() {
 	    // already exists:
 	    references = reference_cell.get_text().match("# References")[0] + "\n\n";
 	}
-//............................................................    
+//............................................................
 
-if (bibmsg!="") {references += '<mark> <b>' +  bibmsg + '</b> </mark>'}; 
-var str="Nothing yet"    
+if (bibmsg!="") {references += '<mark> <b>' +  bibmsg + '</b> </mark>'};
+var str="Nothing yet"
 for (key in  cit_table) {  // cit_table is populated during the edition and rendering of each markdown cell. It is possible to reload all citations by pressing the toolbar LaTeX refresh button
     var citation = document.bibliography[key.toUpperCase()];
-	var opening_cit='[';  var closing_cit=']';                
+	var opening_cit='[';  var closing_cit=']';
     if (cite_by=='apalike'){var opening_cit='(';  var closing_cit=')' }
-     str = opening_cit +'<a id="cit-'+ key + '"'+' href="#call-' + key + '">' 
+     str = opening_cit +'<a id="cit-'+ key + '"'+' href="#call-' + key + '">'
                 +  cit_table[key]['key']  + '</a>' + closing_cit+' '
     if (!(citation==undefined)){
 		//check the type of citation, eg ARTICLE, INPROCEEDINGS, INBOOK, etc
         if (citation['reftype'] in cit_tpl) {var type=citation['reftype']} else {var type='UNKNOWN'};
-		
+
 		//replace %words% in template
         str += cit_tpl[type].replace(/%([\w:]+)+%/g, function(rep) {
 				//case of %AUTHOR:format%
@@ -106,10 +106,10 @@ for (key in  cit_table) {  // cit_table is populated during the edition and rend
 				//case of other keywords
 				}
 				else{
-					if (citation[rep.slice(1, -1)]==undefined) 
+					if (citation[rep.slice(1, -1)]==undefined)
 						return "";
 					else
-	        			return citation[rep.slice(1, -1)].replace(/[{}]/g,"") || "";  
+	        			return citation[rep.slice(1, -1)].replace(/[{}]/g,"") || "";
 					}
 				 });
 		//
@@ -120,7 +120,7 @@ for (key in  cit_table) {  // cit_table is populated during the edition and rend
     }
     references += str + '\n\n'
     //console.log(str)
-    
+
     reference_cell.unrender();
     reference_cell.set_text(references);
     reference_cell.render();
@@ -128,7 +128,7 @@ for (key in  cit_table) {  // cit_table is populated during the edition and rend
 }
 
 function generateReferences() {
-	
+
 	readBibliography(createReferenceSection);
 	}
 
@@ -137,7 +137,7 @@ function generateReferences() {
 function authorSplit(singleAuthor) {
     var firstName, givenName, jr;
 	switch (singleAuthor.split(',').length) {
-		case 1: 
+		case 1:
 		    firstName=singleAuthor.split(' ')[0];
 		    givenName=singleAuthor.split(' ')[1];
 		    break;
@@ -149,7 +149,7 @@ function authorSplit(singleAuthor) {
 		    firstName=singleAuthor.split(', ')[2];
 		    givenName=singleAuthor.split(', ')[0];
 		    jr=singleAuthor.split(', ')[1];
-		    break;    
+		    break;
 	}
 	return {firstName:firstName.trim(), givenName:givenName.trim()}
 }
@@ -169,7 +169,7 @@ function formatSingleAuthorObject(author,format){
         var str;
         switch (format){
             case 'InitialsGiven':
-                str = author.firstName.split(' ').reduce(function (x,y){return x+y[0].toUpperCase()+'.'},'') 
+                str = author.firstName.split(' ').reduce(function (x,y){return x+y[0].toUpperCase()+'.'},'')
                 + ' '+ author.givenName;
                 break;
             case 'GivenInitials':
@@ -179,13 +179,13 @@ function formatSingleAuthorObject(author,format){
                 str =  author.firstName + ' '+ author.givenName;
                 break;
             case 'GivenFirst':
-                str =  author.givenName +' '+ author.firstName;   
+                str =  author.givenName +' '+ author.firstName;
                 break;
             case 'Given':
-                str =  author.givenName;   
-                break;                
+                str =  author.givenName;
+                break;
             default:
-                str =  author.firstName +' '+ author.givenName;     
+                str =  author.firstName +' '+ author.givenName;
         }
      return str;
     }
@@ -210,5 +210,3 @@ function formatAuthors(authorsArray, format, etal){
     }
     return str
 }
-
-

--- a/nbextensions/usability/latex_envs/conversion/ipynb_thms_to_html
+++ b/nbextensions/usability/latex_envs/conversion/ipynb_thms_to_html
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #This is to convert to html the notebooks with embedded LaTeX structures
-#as used in the latex_envs extension 
+#as used in the latex_envs extension
 #required: nodejs, perl
 
 listOfFiles=$*
@@ -12,7 +12,7 @@ stillIPython3=false
 nbextensionsDIR=~/.local/share/jupyter/nbextensions
 jup_exe=jupyter
 
-if $stillIPython3  
+if $stillIPython3
 then
 	nbextensionsDIR=~/.ipython/nbextensions
 	jup_exe=ipython3
@@ -36,11 +36,10 @@ do
   nodejs $SDIR/post_html_thms.js < temp.html > ${f%.ipynb}.html
   #echo [Updating links]
   #perl -pi -e s/.ipynb/.html/g ${f%.ipynb}.html
-  echo Done 
+  echo Done
 done
-cp -n $nbextensionsDIR/latex_envs/latex_envs.css . # copy the css file in the same directory as the html
-if $thmsInNbCopied 
+cp -n $nbextensionsDIR/usability/latex_envs/latex_envs.css . # copy the css file in the same directory as the html
+if $thmsInNbCopied
   then rm thmsInNb.tpl #cleaning
 fi
 rm temp.*
-

--- a/nbextensions/usability/latex_envs/conversion/latex_envs.css
+++ b/nbextensions/usability/latex_envs/conversion/latex_envs.css
@@ -26,7 +26,7 @@
 /*****************************************************************
 LaTeX things
 *****************************************************************/
-   
+
     .latex_tmp {text-align: justify;}
 
     .latex_prob,
@@ -39,19 +39,19 @@ LaTeX things
         font-style: normal;
         text-align: justify;
         margin-left: 0px;
-	margin-right: 10px;	
+	margin-right: 10px;
 	margin-top: 0px;
         margin-bottom: 15px;
         background-color: #CCFFCC;
         display: block;
     }
-    
+
     .latex_title {
         float: left;
         font-weight: bold;
-        padding-right: 10px; 
+        padding-right: 10px;
     }
-    
+
     .latex_proofend {
         float: right;
     }
@@ -73,21 +73,21 @@ LaTeX things
       padding: 0;
     }
 
-    
+
     .latex_thm, .latex_theorem, .latex_lem, .latex_cor, .latex_defn, .latex_prop, .latex_rem, .latex_property,
     .latex_lemma, .latex_corollary, .latex_definition, .latex_proposition, .latex_remark, .latex_proof {
-	
+
         display: block;
         text-align: justify;
         margin-right: 10px;
 	margin-left: 0px;
-	margin-top: 0px;	
+	margin-top: 0px;
         margin-bottom: 15px;
         font-style: italic;
         color:black;
         background-color: beige;
     }
-    
+
     .latex_textboxa {
         display: block;
         font-weight: bold;
@@ -106,17 +106,17 @@ LaTeX things
         border-radius: 8px
     }
 
-    img.latex_img { 
-        display: block; 
-        margin:  auto; 
-        /*height: XXXpx; /*  */ 
-        width: 75%; 
+    img.latex_img {
+        display: block;
+        margin:  auto;
+        /*height: XXXpx; /*  */
+        width: 75%;
     }
 
-    p.latex_img { 
-        display: block; 
+    p.latex_img {
+        display: block;
         width: 85%;
-        margin:  auto; 
+        margin:  auto;
         text-align: justify;
     }
 
@@ -127,36 +127,36 @@ GENERAL CONFIG
 
     @font-face {
         font-family: "Computer Modern";
-        src: url('http://9dbb143991406a7c655e-aa5fcb0a5a4ec34cff238a2d56ca4144.r56.cf5.rackcdn.com/cmunss.otf');
+        src: url('//9dbb143991406a7c655e-aa5fcb0a5a4ec34cff238a2d56ca4144.r56.cf5.rackcdn.com/cmunss.otf');
     }
 
     @font-face {
         font-family: "Computer Modern";
         font-weight: bold;
-        src: url('http://9dbb143991406a7c655e-aa5fcb0a5a4ec34cff238a2d56ca4144.r56.cf5.rackcdn.com/cmunsx.otf');
+        src: url('//9dbb143991406a7c655e-aa5fcb0a5a4ec34cff238a2d56ca4144.r56.cf5.rackcdn.com/cmunsx.otf');
     }
     @font-face {
         font-family: "Computer Modern";
         font-style: oblique;
-        src: url('http://9dbb143991406a7c655e-aa5fcb0a5a4ec34cff238a2d56ca4144.r56.cf5.rackcdn.com/cmunsi.otf');
+        src: url('//9dbb143991406a7c655e-aa5fcb0a5a4ec34cff238a2d56ca4144.r56.cf5.rackcdn.com/cmunsi.otf');
     }
 */
    /* @font-face {
         font-family: "Computer Modern";
         font-style: Typewriter;
-        src: url('http://mirrors.ctan.org/fonts/cm-unicode/fonts/otf/cmuntt.otf');
+        src: url('//mirrors.ctan.org/fonts/cm-unicode/fonts/otf/cmuntt.otf');
     }*/
 
     @font-face {
         font-family: "Computer Modern";
         font-weight: bold;
         font-style: oblique;
-        src: url('http://9dbb143991406a7c655e-aa5fcb0a5a4ec34cff238a2d56ca4144.r56.cf5.rackcdn.com/cmunso.otf');
+        src: url('//9dbb143991406a7c655e-aa5fcb0a5a4ec34cff238a2d56ca4144.r56.cf5.rackcdn.com/cmunso.otf');
     }
 
 
     div.cell{
-        width:100%; 
+        width:100%;
         margin-left:auto; /*16% !important;* was preconised but pbs with some browsers*/
         margin-right:auto;
     }
@@ -180,7 +180,7 @@ GENERAL CONFIG
         font-family: "Computer Modern", Arial, "Helvetica Neue",  Helvetica, Geneva, sans-serif;
         line-height: 145%;
         font-size: 130%;
-        color: black; 
+        color: black;
         width:100%;
         /*width:800px;*/
         margin-left:0px;
@@ -196,26 +196,26 @@ color: darkblue;
     .prompt{
         display: None;
     }
-*/    
+*/
 
 /*
-div.output_area 
+div.output_area
 {
     display: block;
     margin-left: auto;
     margin-right: auto
 }
 */
-div.output_subarea.output_text 
+div.output_subarea.output_text
 {
     margin-left: +2%;
 }
 
-div.output_subarea.output_png 
+div.output_subarea.output_png
 {
     margin-left: +10%;
 }
-div.output_subarea.output_svg 
+div.output_subarea.output_svg
 {
     margin-left: +10%;
 }
@@ -230,10 +230,7 @@ div.output_subarea.output_svg
         margin-top: 0.5em;
         display: block;
     }
-    
+
     .warning{
         color: rgb( 240, 20, 20 )
-        }  
-   
-
-
+        }

--- a/nbextensions/usability/latex_envs/conversion/post_html_thms.js
+++ b/nbextensions/usability/latex_envs/conversion/post_html_thms.js
@@ -1,11 +1,11 @@
-// Node.js script for html to html conversion, 
+// Node.js script for html to html conversion,
 // substituting html classes to LaTeX theorem like environment constructs
-// This applies the same substitutions 
+// This applies the same substitutions
 // that we use in the live notebook .
 
 var nbextensionsDir='/.local/share/jupyter/nbextensions' // for Jupyter, '/.ipython/nbextensions' for IPython
 var static_path = "/usr/share/ipython/notebook/static"; //for IPython 3.x on Debian
-// /usr/share/jupyter/notebook/static // probably for Jupyter (on Debian); 
+// /usr/share/jupyter/notebook/static // probably for Jupyter (on Debian);
 var marked = require( static_path + '/components/marked/lib/marked.js');
 
 
@@ -34,13 +34,12 @@ var document={}
 document.bibliography={};
 
 // Read the actual conversion script file, located in $HOME/.../nbextensions
-eval(fs.readFileSync( process.env['HOME'] + nbextensionsDir +"/latex_envs/thmsInNb4.js", 'utf8') );
+eval(fs.readFileSync( process.env['HOME'] + nbextensionsDir +"/usability/latex_envs/thmsInNb4.js", 'utf8') );
 
 
     //IPython.mathjaxutils.init();
     var html_converted = thmsInNbConv(marked,html_to_analyse);
-    
-    process.stdout.write(html_converted);
-																																																	
-});
 
+    process.stdout.write(html_converted);
+
+});

--- a/nbextensions/usability/latex_envs/doc/html/latex_envs.css
+++ b/nbextensions/usability/latex_envs/doc/html/latex_envs.css
@@ -26,7 +26,7 @@
 /*****************************************************************
 LaTeX things
 *****************************************************************/
-   
+
     .latex_tmp {text-align: justify;}
 
     .latex_prob,
@@ -39,19 +39,19 @@ LaTeX things
         font-style: normal;
         text-align: justify;
         margin-left: 0px;
-	margin-right: 10px;	
+	margin-right: 10px;
 	margin-top: 0px;
         margin-bottom: 15px;
         background-color: #CCFFCC;
         display: block;
     }
-    
+
     .latex_title {
         float: left;
         font-weight: bold;
-        padding-right: 10px; 
+        padding-right: 10px;
     }
-    
+
     .latex_proofend {
         float: right;
     }
@@ -73,21 +73,21 @@ LaTeX things
       padding: 0;
     }
 
-    
+
     .latex_thm, .latex_theorem, .latex_lem, .latex_cor, .latex_defn, .latex_prop, .latex_rem, .latex_property,
     .latex_lemma, .latex_corollary, .latex_definition, .latex_proposition, .latex_remark, .latex_proof {
-	
+
         display: block;
         text-align: justify;
         margin-right: 10px;
 	margin-left: 0px;
-	margin-top: 0px;	
+	margin-top: 0px;
         margin-bottom: 15px;
         font-style: italic;
         color:black;
         background-color: beige;
     }
-    
+
     .latex_textboxa {
         display: block;
         font-weight: bold;
@@ -106,17 +106,17 @@ LaTeX things
         border-radius: 8px
     }
 
-    img.latex_img { 
-        display: block; 
-        margin:  auto; 
-        /*height: XXXpx; /*  */ 
-        width: 75%; 
+    img.latex_img {
+        display: block;
+        margin:  auto;
+        /*height: XXXpx; /*  */
+        width: 75%;
     }
 
-    p.latex_img { 
-        display: block; 
+    p.latex_img {
+        display: block;
         width: 85%;
-        margin:  auto; 
+        margin:  auto;
         text-align: justify;
     }
 
@@ -127,36 +127,36 @@ GENERAL CONFIG
 
     @font-face {
         font-family: "Computer Modern";
-        src: url('http://9dbb143991406a7c655e-aa5fcb0a5a4ec34cff238a2d56ca4144.r56.cf5.rackcdn.com/cmunss.otf');
+        src: url('//9dbb143991406a7c655e-aa5fcb0a5a4ec34cff238a2d56ca4144.r56.cf5.rackcdn.com/cmunss.otf');
     }
 
     @font-face {
         font-family: "Computer Modern";
         font-weight: bold;
-        src: url('http://9dbb143991406a7c655e-aa5fcb0a5a4ec34cff238a2d56ca4144.r56.cf5.rackcdn.com/cmunsx.otf');
+        src: url('//9dbb143991406a7c655e-aa5fcb0a5a4ec34cff238a2d56ca4144.r56.cf5.rackcdn.com/cmunsx.otf');
     }
     @font-face {
         font-family: "Computer Modern";
         font-style: oblique;
-        src: url('http://9dbb143991406a7c655e-aa5fcb0a5a4ec34cff238a2d56ca4144.r56.cf5.rackcdn.com/cmunsi.otf');
+        src: url('//9dbb143991406a7c655e-aa5fcb0a5a4ec34cff238a2d56ca4144.r56.cf5.rackcdn.com/cmunsi.otf');
     }
 */
    /* @font-face {
         font-family: "Computer Modern";
         font-style: Typewriter;
-        src: url('http://mirrors.ctan.org/fonts/cm-unicode/fonts/otf/cmuntt.otf');
+        src: url('//mirrors.ctan.org/fonts/cm-unicode/fonts/otf/cmuntt.otf');
     }*/
 
     @font-face {
         font-family: "Computer Modern";
         font-weight: bold;
         font-style: oblique;
-        src: url('http://9dbb143991406a7c655e-aa5fcb0a5a4ec34cff238a2d56ca4144.r56.cf5.rackcdn.com/cmunso.otf');
+        src: url('//9dbb143991406a7c655e-aa5fcb0a5a4ec34cff238a2d56ca4144.r56.cf5.rackcdn.com/cmunso.otf');
     }
 
 
     div.cell{
-        width:100%; 
+        width:100%;
         margin-left:auto; /*16% !important;* was preconised but pbs with some browsers*/
         margin-right:auto;
     }
@@ -180,7 +180,7 @@ GENERAL CONFIG
         font-family: "Computer Modern", Arial, "Helvetica Neue",  Helvetica, Geneva, sans-serif;
         line-height: 145%;
         font-size: 130%;
-        color: black; 
+        color: black;
         width:100%;
         /*width:800px;*/
         margin-left:0px;
@@ -196,26 +196,26 @@ color: darkblue;
     .prompt{
         display: None;
     }
-*/    
+*/
 
 /*
-div.output_area 
+div.output_area
 {
     display: block;
     margin-left: auto;
     margin-right: auto
 }
 */
-div.output_subarea.output_text 
+div.output_subarea.output_text
 {
     margin-left: +2%;
 }
 
-div.output_subarea.output_png 
+div.output_subarea.output_png
 {
     margin-left: +10%;
 }
-div.output_subarea.output_svg 
+div.output_subarea.output_svg
 {
     margin-left: +10%;
 }
@@ -230,10 +230,7 @@ div.output_subarea.output_svg
         margin-top: 0.5em;
         display: block;
     }
-    
+
     .warning{
         color: rgb( 240, 20, 20 )
-        }  
-   
-
-
+        }

--- a/nbextensions/usability/latex_envs/doc/latex_envs.css
+++ b/nbextensions/usability/latex_envs/doc/latex_envs.css
@@ -26,7 +26,7 @@
 /*****************************************************************
 LaTeX things
 *****************************************************************/
-   
+
     .latex_tmp {text-align: justify;}
 
     .latex_prob,
@@ -39,19 +39,19 @@ LaTeX things
         font-style: normal;
         text-align: justify;
         margin-left: 0px;
-	margin-right: 10px;	
+	margin-right: 10px;
 	margin-top: 0px;
         margin-bottom: 15px;
         background-color: #CCFFCC;
         display: block;
     }
-    
+
     .latex_title {
         float: left;
         font-weight: bold;
-        padding-right: 10px; 
+        padding-right: 10px;
     }
-    
+
     .latex_proofend {
         float: right;
     }
@@ -73,21 +73,21 @@ LaTeX things
       padding: 0;
     }
 
-    
+
     .latex_thm, .latex_theorem, .latex_lem, .latex_cor, .latex_defn, .latex_prop, .latex_rem, .latex_property,
     .latex_lemma, .latex_corollary, .latex_definition, .latex_proposition, .latex_remark, .latex_proof {
-	
+
         display: block;
         text-align: justify;
         margin-right: 10px;
 	margin-left: 0px;
-	margin-top: 0px;	
+	margin-top: 0px;
         margin-bottom: 15px;
         font-style: italic;
         color:black;
         background-color: beige;
     }
-    
+
     .latex_textboxa {
         display: block;
         font-weight: bold;
@@ -106,17 +106,17 @@ LaTeX things
         border-radius: 8px
     }
 
-    img.latex_img { 
-        display: block; 
-        margin:  auto; 
-        /*height: XXXpx; /*  */ 
-        width: 75%; 
+    img.latex_img {
+        display: block;
+        margin:  auto;
+        /*height: XXXpx; /*  */
+        width: 75%;
     }
 
-    p.latex_img { 
-        display: block; 
+    p.latex_img {
+        display: block;
         width: 85%;
-        margin:  auto; 
+        margin:  auto;
         text-align: justify;
     }
 
@@ -127,36 +127,36 @@ GENERAL CONFIG
 
     @font-face {
         font-family: "Computer Modern";
-        src: url('http://9dbb143991406a7c655e-aa5fcb0a5a4ec34cff238a2d56ca4144.r56.cf5.rackcdn.com/cmunss.otf');
+        src: url('//9dbb143991406a7c655e-aa5fcb0a5a4ec34cff238a2d56ca4144.r56.cf5.rackcdn.com/cmunss.otf');
     }
 
     @font-face {
         font-family: "Computer Modern";
         font-weight: bold;
-        src: url('http://9dbb143991406a7c655e-aa5fcb0a5a4ec34cff238a2d56ca4144.r56.cf5.rackcdn.com/cmunsx.otf');
+        src: url('//9dbb143991406a7c655e-aa5fcb0a5a4ec34cff238a2d56ca4144.r56.cf5.rackcdn.com/cmunsx.otf');
     }
     @font-face {
         font-family: "Computer Modern";
         font-style: oblique;
-        src: url('http://9dbb143991406a7c655e-aa5fcb0a5a4ec34cff238a2d56ca4144.r56.cf5.rackcdn.com/cmunsi.otf');
+        src: url('//9dbb143991406a7c655e-aa5fcb0a5a4ec34cff238a2d56ca4144.r56.cf5.rackcdn.com/cmunsi.otf');
     }
 */
    /* @font-face {
         font-family: "Computer Modern";
         font-style: Typewriter;
-        src: url('http://mirrors.ctan.org/fonts/cm-unicode/fonts/otf/cmuntt.otf');
+        src: url('//mirrors.ctan.org/fonts/cm-unicode/fonts/otf/cmuntt.otf');
     }*/
 
     @font-face {
         font-family: "Computer Modern";
         font-weight: bold;
         font-style: oblique;
-        src: url('http://9dbb143991406a7c655e-aa5fcb0a5a4ec34cff238a2d56ca4144.r56.cf5.rackcdn.com/cmunso.otf');
+        src: url('//9dbb143991406a7c655e-aa5fcb0a5a4ec34cff238a2d56ca4144.r56.cf5.rackcdn.com/cmunso.otf');
     }
 
 
     div.cell{
-        width:100%; 
+        width:100%;
         margin-left:auto; /*16% !important;* was preconised but pbs with some browsers*/
         margin-right:auto;
     }
@@ -180,7 +180,7 @@ GENERAL CONFIG
         font-family: "Computer Modern", Arial, "Helvetica Neue",  Helvetica, Geneva, sans-serif;
         line-height: 145%;
         font-size: 130%;
-        color: black; 
+        color: black;
         width:100%;
         /*width:800px;*/
         margin-left:0px;
@@ -196,26 +196,26 @@ color: darkblue;
     .prompt{
         display: None;
     }
-*/    
+*/
 
 /*
-div.output_area 
+div.output_area
 {
     display: block;
     margin-left: auto;
     margin-right: auto
 }
 */
-div.output_subarea.output_text 
+div.output_subarea.output_text
 {
     margin-left: +2%;
 }
 
-div.output_subarea.output_png 
+div.output_subarea.output_png
 {
     margin-left: +10%;
 }
-div.output_subarea.output_svg 
+div.output_subarea.output_svg
 {
     margin-left: +10%;
 }
@@ -230,10 +230,7 @@ div.output_subarea.output_svg
         margin-top: 0.5em;
         display: block;
     }
-    
+
     .warning{
         color: rgb( 240, 20, 20 )
-        }  
-   
-
-
+        }

--- a/nbextensions/usability/latex_envs/latex_envs.css
+++ b/nbextensions/usability/latex_envs/latex_envs.css
@@ -26,7 +26,7 @@
 /*****************************************************************
 LaTeX things
 *****************************************************************/
-   
+
     .latex_tmp {text-align: justify;}
 
     .latex_prob,
@@ -39,19 +39,19 @@ LaTeX things
         font-style: normal;
         text-align: justify;
         margin-left: 0px;
-	margin-right: 10px;	
+	margin-right: 10px;
 	margin-top: 0px;
         margin-bottom: 15px;
         background-color: #CCFFCC;
         display: block;
     }
-    
+
     .latex_title {
         float: left;
         font-weight: bold;
-        padding-right: 10px; 
+        padding-right: 10px;
     }
-    
+
     .latex_proofend {
         float: right;
     }
@@ -73,21 +73,21 @@ LaTeX things
       padding: 0;
     }
 
-    
+
     .latex_thm, .latex_theorem, .latex_lem, .latex_cor, .latex_defn, .latex_prop, .latex_rem, .latex_property,
     .latex_lemma, .latex_corollary, .latex_definition, .latex_proposition, .latex_remark, .latex_proof {
-	
+
         display: block;
         text-align: justify;
         margin-right: 10px;
 	margin-left: 0px;
-	margin-top: 0px;	
+	margin-top: 0px;
         margin-bottom: 15px;
         font-style: italic;
         color:black;
         background-color: beige;
     }
-    
+
     .latex_textboxa {
         display: block;
         font-weight: bold;
@@ -106,17 +106,17 @@ LaTeX things
         border-radius: 8px
     }
 
-    img.latex_img { 
-        display: block; 
-        margin:  auto; 
-        /*height: XXXpx; /*  */ 
-        width: 75%; 
+    img.latex_img {
+        display: block;
+        margin:  auto;
+        /*height: XXXpx; /*  */
+        width: 75%;
     }
 
-    p.latex_img { 
-        display: block; 
+    p.latex_img {
+        display: block;
         width: 85%;
-        margin:  auto; 
+        margin:  auto;
         text-align: justify;
     }
 
@@ -127,36 +127,36 @@ GENERAL CONFIG
 
     @font-face {
         font-family: "Computer Modern";
-        src: url('http://9dbb143991406a7c655e-aa5fcb0a5a4ec34cff238a2d56ca4144.r56.cf5.rackcdn.com/cmunss.otf');
+        src: url('//9dbb143991406a7c655e-aa5fcb0a5a4ec34cff238a2d56ca4144.r56.cf5.rackcdn.com/cmunss.otf');
     }
 
     @font-face {
         font-family: "Computer Modern";
         font-weight: bold;
-        src: url('http://9dbb143991406a7c655e-aa5fcb0a5a4ec34cff238a2d56ca4144.r56.cf5.rackcdn.com/cmunsx.otf');
+        src: url('//9dbb143991406a7c655e-aa5fcb0a5a4ec34cff238a2d56ca4144.r56.cf5.rackcdn.com/cmunsx.otf');
     }
     @font-face {
         font-family: "Computer Modern";
         font-style: oblique;
-        src: url('http://9dbb143991406a7c655e-aa5fcb0a5a4ec34cff238a2d56ca4144.r56.cf5.rackcdn.com/cmunsi.otf');
+        src: url('//9dbb143991406a7c655e-aa5fcb0a5a4ec34cff238a2d56ca4144.r56.cf5.rackcdn.com/cmunsi.otf');
     }
 */
    /* @font-face {
         font-family: "Computer Modern";
         font-style: Typewriter;
-        src: url('http://mirrors.ctan.org/fonts/cm-unicode/fonts/otf/cmuntt.otf');
+        src: url('//mirrors.ctan.org/fonts/cm-unicode/fonts/otf/cmuntt.otf');
     }*/
 
     @font-face {
         font-family: "Computer Modern";
         font-weight: bold;
         font-style: oblique;
-        src: url('http://9dbb143991406a7c655e-aa5fcb0a5a4ec34cff238a2d56ca4144.r56.cf5.rackcdn.com/cmunso.otf');
+        src: url('//9dbb143991406a7c655e-aa5fcb0a5a4ec34cff238a2d56ca4144.r56.cf5.rackcdn.com/cmunso.otf');
     }
 
 
     div.cell{
-        width:100%; 
+        width:100%;
         margin-left:auto; /*16% !important;* was preconised but pbs with some browsers*/
         margin-right:auto;
     }
@@ -180,7 +180,7 @@ GENERAL CONFIG
         font-family: "Computer Modern", Arial, "Helvetica Neue",  Helvetica, Geneva, sans-serif;
         line-height: 145%;
         font-size: 130%;
-        color: black; 
+        color: black;
         width:100%;
         /*width:800px;*/
         margin-left:0px;
@@ -196,26 +196,26 @@ color: darkblue;
     .prompt{
         display: None;
     }
-*/    
+*/
 
 /*
-div.output_area 
+div.output_area
 {
     display: block;
     margin-left: auto;
     margin-right: auto
 }
 */
-div.output_subarea.output_text 
+div.output_subarea.output_text
 {
     margin-left: +2%;
 }
 
-div.output_subarea.output_png 
+div.output_subarea.output_png
 {
     margin-left: +10%;
 }
-div.output_subarea.output_svg 
+div.output_subarea.output_svg
 {
     margin-left: +10%;
 }
@@ -230,10 +230,7 @@ div.output_subarea.output_svg
         margin-top: 0.5em;
         display: block;
     }
-    
+
     .warning{
         color: rgb( 240, 20, 20 )
-        }  
-   
-
-
+        }

--- a/nbextensions/usability/latex_envs/latex_envs.js
+++ b/nbextensions/usability/latex_envs/latex_envs.js
@@ -15,7 +15,7 @@ var cite_by, bibliofile, eqNumInitial, eqNum, eqLabelWithNumbers; //These variab
 //var eqLabelWithNumbers = true; //if true, label equations with equation numbers; otherwise using the tag specified by \label
 
 //BIBLIOGRAPHY
-//var cite_by = 'apalike'  //cite by 'number', 'key' or 'apalike' 
+//var cite_by = 'apalike'  //cite by 'number', 'key' or 'apalike'
 var current_citInitial=1;
 var current_cit=current_citInitial; // begins citation numbering at current_cit
 //var bibliofile = 'biblio.bib' //or IPython.notebook.notebook_name.split(".")[0]+."bib"
@@ -39,17 +39,17 @@ Authors can be formatted according to the following keywords:
 - %AUTHOR:GivenFirst%, i.e. Smith John
 - %AUTHOR:InitialsGiven%, i.e. J. Smith
 - %AUTHOR:GivenInitials%, i.e. Smith J.
-- %AUTHOR:Given%, i.e. Smith 
+- %AUTHOR:Given%, i.e. Smith
 */
 
 // *****************************************************************************
 
-    
-define(["require", 
+
+define(["require",
 	'base/js/namespace',
-	"/nbextensions/latex_envs/thmsInNb4.js",
-	"/nbextensions/latex_envs/bibInNb4.js",
-	"/nbextensions/latex_envs/initNb.js"], function (require,Jupyter, thmsInNb, bibsInNb,initNb) {    
+	"/nbextensions/usability/latex_envs/thmsInNb4.js",
+	"/nbextensions/usability/latex_envs/bibInNb4.js",
+	"/nbextensions/usability/latex_envs/initNb.js"], function (require,Jupyter, thmsInNb, bibsInNb,initNb) {
 
     var maps = initmap();
     environmentMap=maps[0];
@@ -67,7 +67,7 @@ define(["require",
 	var security=require("base/js/security")
  	var marked = require('components/marked/lib/marked');
 
-    //define(["require"], function (require) { 
+    //define(["require"], function (require) {
     var load_css = function(name) {
         var link = document.createElement("link");
         link.type = "text/css";
@@ -77,15 +77,15 @@ define(["require",
         document.getElementsByTagName("head")[0].appendChild(link);
 
     };
-  
+
 	var load_ipython_extension = require(['base/js/namespace'], function(Jupyter){
-		
+
 		"use strict";
 		if (Jupyter.version[0] < 3) {
             console.log("This extension requires Jupyter or IPython >= 3.x")
             return
         	}
-	
+
         var _on_reload = true; /* make sure cells render on reload */
 
 
@@ -130,20 +130,20 @@ define(["require",
         return cont;
     };
 
-     
+
         //init_cells();
-		readBibliography(function (){ 
-					init_cells(); 
+		readBibliography(function (){
+					init_cells();
 					createReferenceSection();
 					});
 
-        
+
 		/* on reload */
         $([Jupyter.events]).on('status_started.Kernel', function() {
 
             //init_cells();
-			readBibliography(function (){ 
-					init_cells(); 
+			readBibliography(function (){
+					init_cells();
 					createReferenceSection();
 					});
             _on_reload = false;
@@ -159,12 +159,12 @@ define(["require",
                 },
 				{
 			'label'   : 'Read bibliography and generate references section',
-			'icon'    : 'fa-book', 
+			'icon'    : 'fa-book',
 			'callback': generateReferences
 				},
 				{
 			'label'   : 'LaTeX_envs: Some configuration options (toogle toolbar)',
-			'icon'    : 'fa-wrench', 
+			'icon'    : 'fa-wrench',
 			'callback': config_toolbar
 				}
             ]);
@@ -172,16 +172,16 @@ define(["require",
 
 
    // });
-    
+
 }); //end of load_ipython_extension function
 
     console.log("Loading latex_envs.css");
 
     //load_css('/nbextensions/latex_envs.css')
     load_css('./latex_envs.css')
-  
 
-    
+
+
     //load_ipython_extension();
     return {
         load_ipython_extension: load_ipython_extension,

--- a/nbextensions/usability/latex_envs/latex_envs_jup.js
+++ b/nbextensions/usability/latex_envs/latex_envs_jup.js
@@ -15,7 +15,7 @@ var cite_by, bibliofile, eqNumInitial, eqNum, eqLabelWithNumbers; //These variab
 //var eqLabelWithNumbers = true; //if true, label equations with equation numbers; otherwise using the tag specified by \label
 
 //BIBLIOGRAPHY
-//var cite_by = 'apalike'  //cite by 'number', 'key' or 'apalike' 
+//var cite_by = 'apalike'  //cite by 'number', 'key' or 'apalike'
 var current_citInitial=1;
 var current_cit=current_citInitial; // begins citation numbering at current_cit
 //var bibliofile = 'biblio.bib' //or IPython.notebook.notebook_name.split(".")[0]+."bib"
@@ -39,17 +39,17 @@ Authors can be formatted according to the following keywords:
 - %AUTHOR:GivenFirst%, i.e. Smith John
 - %AUTHOR:InitialsGiven%, i.e. J. Smith
 - %AUTHOR:GivenInitials%, i.e. Smith J.
-- %AUTHOR:Given%, i.e. Smith 
+- %AUTHOR:Given%, i.e. Smith
 */
 
 // *****************************************************************************
 
-    
-define(["require", 
+
+define(["require",
 	'base/js/namespace',
-	"/nbextensions/latex_envs/thmsInNb4.js",
-	"/nbextensions/latex_envs/bibInNb4.js",
-	"/nbextensions/latex_envs/initNb.js"], function (require,Jupyter, thmsInNb, bibsInNb,initNb) {    
+	"/nbextensions/usability/latex_envs/thmsInNb4.js",
+	"/nbextensions/usability/latex_envs/bibInNb4.js",
+	"/nbextensions/usability/latex_envs/initNb.js"], function (require,Jupyter, thmsInNb, bibsInNb,initNb) {
 
     var maps = initmap();
     environmentMap=maps[0];
@@ -67,7 +67,7 @@ define(["require",
 	var security=require("base/js/security")
  	var marked = require('components/marked/lib/marked');
 
-    //define(["require"], function (require) { 
+    //define(["require"], function (require) {
     var load_css = function(name) {
         var link = document.createElement("link");
         link.type = "text/css";
@@ -77,15 +77,15 @@ define(["require",
         document.getElementsByTagName("head")[0].appendChild(link);
 
     };
-  
+
 	var load_ipython_extension = require(['base/js/namespace'], function(Jupyter){
-		
+
 		"use strict";
 		if (Jupyter.version[0] < 3) {
             console.log("This extension requires Jupyter or IPython >= 3.x")
             return
         	}
-	
+
         var _on_reload = true; /* make sure cells render on reload */
 
 
@@ -130,20 +130,20 @@ define(["require",
         return cont;
     };
 
-     
+
         //init_cells();
-		readBibliography(function (){ 
-					init_cells(); 
+		readBibliography(function (){
+					init_cells();
 					createReferenceSection();
 					});
 
-        
+
 		/* on reload */
         $([Jupyter.events]).on('status_started.Kernel', function() {
 
             //init_cells();
-			readBibliography(function (){ 
-					init_cells(); 
+			readBibliography(function (){
+					init_cells();
 					createReferenceSection();
 					});
             _on_reload = false;
@@ -159,12 +159,12 @@ define(["require",
                 },
 				{
 			'label'   : 'Read bibliography and generate references section',
-			'icon'    : 'fa-book', 
+			'icon'    : 'fa-book',
 			'callback': generateReferences
 				},
 				{
 			'label'   : 'LaTeX_envs: Some configuration options (toogle toolbar)',
-			'icon'    : 'fa-wrench', 
+			'icon'    : 'fa-wrench',
 			'callback': config_toolbar
 				}
             ]);
@@ -172,16 +172,16 @@ define(["require",
 
 
    // });
-    
+
 }); //end of load_ipython_extension function
 
     console.log("Loading latex_envs.css");
 
     //load_css('/nbextensions/latex_envs.css')
     load_css('./latex_envs.css')
-  
 
-    
+
+
     //load_ipython_extension();
     return {
         load_ipython_extension: load_ipython_extension,


### PR DESCRIPTION
…ont paths - this allows loading fronts from https sites.

This fixes #296

Sorry about the trailing white spaces removal... had my editor set to do that. I think we can benefit from that as trailing whitespace is useless in js files and a waste.

For easier comparison, here is the diff with the trailing whitespace ignored ( added ?w=1 to the diff url )

https://github.com/ipython-contrib/IPython-notebook-extensions/pull/297/files?w=1
