### PR TITLE
Config/rendermd

### DIFF
--- a/extensions/nbextensions.py
+++ b/extensions/nbextensions.py
@@ -88,22 +88,24 @@ class NBExtensionHandler(IPythonHandler):
 
 class RenderExtensionHandler(IPythonHandler):
     """Render  given markdown file"""
+
     @web.authenticated
     def get(self, path):
+        if not path.endswith('.md'):
+            # for all non-markdown items, we redirect to the actual file
+            self.redirect(self.base_url + path)
         self.write(self.render_template('rendermd.html',
             base_url=self.base_url,
-            render_url=path,
+            md_url=path,
             page_title=path,
-            )
-        )
+        ))
 
 
 def load_jupyter_server_extension(nbapp):
     webapp = nbapp.web_app
     base_url = webapp.settings['base_url']
-    mdregex = r'([^"\'>]+.md)'
+
     webapp.add_handlers(".*$", [
-        (ujoin(base_url, r"/rendermd/%s" % mdregex), RenderExtensionHandler),
         (ujoin(base_url, r"/nbextensions"), NBExtensionHandler),
-        (ujoin(base_url, r"/nbextensions/"), NBExtensionHandler)
+        (ujoin(base_url, r"/nbextensions/config/rendermd/(.*)"), RenderExtensionHandler),
     ])

--- a/nbextensions/config/main.css
+++ b/nbextensions/config/main.css
@@ -6,6 +6,38 @@
     -moz-box-shadow: 0 0 12px 1px rgba(87, 87, 87, 0.2);
     -webkit-box-shadow: 0 0 12px 1px rgba(87, 87, 87, 0.2);
     box-shadow: 0 0 12px 1px rgba(87, 87, 87, 0.2);
+    min-height: calc(100% - 15px);
+}
+
+#render-container.text-danger {
+    padding-top: 15px;
+}
+
+#render-container img {
+  margin-top: 1em;
+  margin-bottom: 1em;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+#render-container img,
+#render-container svg {
+  max-width: 100%;
+  height: auto;
+}
+
+#render-container img.unconfined,
+#render-container svg.unconfined {
+  max-width: none;
+}
+
+#render-container pre {
+  padding: 0.25em 0.5em 0.25em;
+  margin: 0.5em 0 0.5em;
+}
+
+#render-container code {
+  font-size: 100%;
 }
 
 .nbext-page-title-wrap {

--- a/nbextensions/config/main.js
+++ b/nbextensions/config/main.js
@@ -381,7 +381,7 @@ require([
                 if (extension.Link !== undefined) {
                     var link = extension.Link;
                     if (!/^(f|ht)tps?:\/\//i.test(link)) {
-                        link = base_url + 'rendermd/' + extension['url'] +'/' + link;
+                        link = base_url + 'nbextensions/config/rendermd/' + extension['url'] +'/' + link;
                     }
                     link = $('<a>').attr('href', link).text('more...');
                     link.appendTo(div_compat_and_desc);

--- a/nbextensions/config/render.js
+++ b/nbextensions/config/render.js
@@ -22,9 +22,28 @@ define([
     var md_url = $('body').data('md-url');
 
     var url = base_url +  md_url;
-    $.get(url, function( my_var ) {
-        $("#render-container").html(marked(my_var));
-    }, 'text');  // or 'text', 'xml', 'more' */
+    $.ajax({
+        url: url,
+        dataType: 'text', // or 'html', 'xml', 'more' */
+        success: function(md_contents) {
+            $("#render-container").html(marked(md_contents));
+        },
+        error: function(jqXHR, textStatus, errorThrown) {
+            $(".nbext-page-title-wrap").append(
+                $('<span class="nbext-page-title text-danger"/>').text(
+                    textStatus + ' : ' + jqXHR.status + ' ' + errorThrown
+                )
+            );
+            $("#render-container").addClass("text-danger bg-danger");
+            var body_txt = "";
+            switch (jqXHR.status) {
+                case 404:
+                    body_txt = 'no markdown file at ' + url;
+                    break;
+            }
+            $("#render-container").append(body_txt);
+        }
+    });
 
     /**
      * Add CSS file to page

--- a/nbextensions/config/render.js
+++ b/nbextensions/config/render.js
@@ -3,20 +3,19 @@
 
 // Render markdown url
 
-require([
-    'base/js/namespace',
+define([
+    'require',
+    'jquery',
     'base/js/utils',
     'base/js/page',
-    'jquery',
-    'require',
     'components/marked/lib/marked'
 ], function(
-    IPython,
+    require,
+    $,
     utils,
     page,
-    $, require,
     marked
-    ){
+){
     page = new page.Page();
 
     var base_url = utils.get_body_data('baseUrl');
@@ -43,6 +42,6 @@ require([
         document.getElementsByTagName("head")[0].appendChild(link);
     };
 
-    add_css('/nbextensions/config/main.css');
+    add_css('./main.css');
     page.show();
 });

--- a/nbextensions/config/render.js
+++ b/nbextensions/config/render.js
@@ -20,9 +20,6 @@ define([
 
     var base_url = utils.get_body_data('baseUrl');
     var md_url = $('body').data('md-url');
-    /* build html body listing all extensions */
-    var html = "";
-    $("#nbextensions-container").html(html);
 
     var url = base_url +  md_url;
     $.get(url, function( my_var ) {

--- a/templates/rendermd.html
+++ b/templates/rendermd.html
@@ -9,7 +9,7 @@
 {% block params %}
 
 data-base-url='{{base_url}}'
-data-md-url='{{render_url}}'
+data-md-url='{{md_url}}'
 
 {% endblock %}
 
@@ -27,6 +27,9 @@ data-md-url='{{render_url}}'
 
 {% block site %}
 
+{# we could make everything look like notebook-formatted markdown cells by
+adding the "rendered_html" class, but it doesn't look so good for full-page
+readme files, so for now I haven't bothered #}
 <div id="render-container" class="container"></div>
 
 {% endblock %}
@@ -35,5 +38,7 @@ data-md-url='{{render_url}}'
 
     {{super()}}
 
-<script src="{{ "/nbextensions/config/render.js" }}" type="text/javascript" charset="utf-8"></script>
+<script type="text/javascript" charset="utf-8">
+	require(["nbextensions/config/render"]);
+</script>
 {% endblock %}


### PR DESCRIPTION
* use server-side redirects to support relative links in rendered markdown
* use jquery ajax to provide feedback if an error occurs getting markdown file for rendering
* make `render.js` a module, so it can use `require.toUrl` correctly with relative module names
* remove redundant lines from `render.js`