### PR TITLE
WIP: Allow Drag&drop a notebook

### DIFF
--- a/nbextensions/usability/dragdrop/readme.md
+++ b/nbextensions/usability/dragdrop/readme.md
@@ -1,37 +1,34 @@
-This IPython notebook extension allows dragging&dropping images from the desktop or other programs into a notebook. A new markdown cell is created below the currently selected cell and the image is embedded.
-The notebook has been tested with Firefox and Chrome.
+Description
+===========
+
+This IPython notebook extension allows dragging&dropping images and ipynb notebooks from the desktop or other programs into a notebook. 
+
+For images, a new markdown cell is created below the currently selected cell and the image is embedded.
+Supported types are `png`, `jpg`, `svg`.
 
 A demo video showing drag&drop of images is here:
 http://youtu.be/buAL1bTZ73c
 
-
-Installation
-============
-Copy the contents of the `dragdrop` directory to a new `/nbextensions/usability/dragdrop` directory of your user's IPython directory, or from IPython simply call
-
-```python
-import IPython
-IPython.html.nbextensions.install_nbextension('https://raw.github.com/ipython-contrib/IPython-notebook-extensions/master/nbextensions/usability/dragdrop/main.js')
-```
-
-Then load the extension from within the IPython notebook:
-
-```javascript
-%%javascript
-IPython.load_extensions('usability/dragdrop/main');
-```
-
-Or, for permanent installation instructions, please see the [readme](../../README.md),
-or the [wiki](https://github.com/ipython-contrib/IPython-notebook-extensions/wiki).
+Additionally, ipynb notebooks can be dropped into the current notebook. All content of the dragged source notebook will
+be added below the current selected cell in the target notebook.
 
 
 Internals
 =========
 
-The image will be uploaded to the server into the directory where your notebook resides. This means, the image is not copied into the notebook itself, it will only be linked to. The markdown cell in the notebook will contain this tag:
+A dropped image will be uploaded to the server into the directory where your notebook resides. This means, the image is not 
+stored in the notebook itself, it will only be linked to. Storing images directly in a notebook is not recommended and
+therefore has not been implemented.
+
+The markdown cell in the notebook will contain this tag:
 
 ```html
 <img  src="http://127.0.0.1:8888/notebooks/myimage.png"/>
 ```
 
-If you run `nbconvert` to generate a HTML file, this image will remain outside of the html file. You can embedd all images by calling `nbconvert` with the option `--post=embed.EmbedPostProcessor`. The file `embed.py`, located in the same directory of this extension needs to be in `PYTHONPATH` to be found.
+It might be better to use the markdown tag `!()[]` in future. Please open a GitHub issue if you have thoughts on this.
+
+To export notebooks containing images to HTML, it might be useful to embed the images directly. This can be achieved
+using the `EmbedPostProcessor`. The postprocessor should be automatically installed with the IPython-notebook-extensions
+package and is located in `/extensions/post_embedhtml.py`.
+


### PR DESCRIPTION
Allow dragging a source notebook into a target notebook. Adds all cells from source notebook below currently selected cell in target notebook. Only Chrome code path is implemented.

TODO:
* testing...
* understand why `cell_data.source = cell_data.source[0];` is necessary
* add Firefox support (simply copy&paste code)