### PR TITLE
Update meta.yaml

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -19,6 +19,7 @@ requirements:
     - nbformat
     - python
     - traitlets
+    - psutil
 
   run:
     - ipython >=4


### PR DESCRIPTION
with the latest anaconda, I can't `conda build` unless the `psutil` are available.