### PR TITLE
updates to config readme:

### DIFF
--- a/nbextensions/config/readme.md
+++ b/nbextensions/config/readme.md
@@ -26,161 +26,164 @@ You can see a video of the config extension in action on youtube:
 
 <iframe width="420" height="315" src="https://www.youtube.com/embed/h9DEfxZSz2M" frameborder="0" allowfullscreen></iframe>
 
+
 Setup procedure
 ===============
 
 The most recent version
-can be found here:
-[master.zip](https://github.com/ipython-contrib/IPython-notebook-extensions/archive/master.zip)   
+of the repository can be found as a zip archive here:
+[master.zip](https://github.com/ipython-contrib/IPython-notebook-extensions/archive/master.zip)
 
-https://binstar.org/juhasch/nbextensions
 
-1. Installation
----------------
+Installation
+============
 
-There are several ways to install the IPython-contrib extensions package:
-
- a) Using `setup.py` 777  
-After downloading the most recent version from GitHub [master.zip](https://github.com/ipython-contrib/IPython-notebook-extensions/archive/master.zip),
-   unpack the archive and run `python setup.py install`. This will copy all extensions to your local Jupyter installation
-   and configure the extensions to work.   
-
- b) Installing the Anaconda package   
-When using the Anaconda Python installation (highly recommended), you can install the package using the
-  `conda install -c https://conda.binstar.org/juhasch nbextensions` command. Alternatively, you can download the latest master
-  version and do a `conda build IPython-notebook-extensions` yourself to build the Anaconda package.
-  
-c) Manual installation (see below)
-
-The easiest way is to do a) and install the extensions using the `python setup.py install` command.
-
+There are several ways to install the IPython-contrib extensions package, listed below.
+The easiest way is the first listed, to install the extensions using the
+`python setup.py install` command.
 
 Having restarted the server after the installation, you should be able to see the configuration page by going to the URL `/nbextensions`.
-Otherwise, you can use the detailed instructions below - good luck!
 
-**Note**: The notebook server is not allowed to run during installation.
-
-1a. Manual Installation
------------------------
-
- * copy the `nbextensions` folder to `~/Library/Jupyter` (on MacOs, for help locating Jupyter data dir on other OS look in 3.)
- * copy the `extensions` folder to `~/Library/Jupyter`
- * copy the `templates` folder to `~/Library/Jupyter`
+Otherwise, you can use the detailed manual installation instructions below - good luck!
 
 
-2. Configuration
-----------------
 
-There are two configuration steps required:
+1. __Using `setup.py`__  
+  After downloading the most recent version from GitHub
+  [master.zip](https://github.com/ipython-contrib/IPython-notebook-extensions/archive/master.zip),
+  unpack the archive and run
 
- 1. Edit your `.jupyter/jupyter_notebook_config.py` file (on MacOs, for help locating the Jupyter config dir on other OS look in 3.):
-     ```
+  ```bash
+  python setup.py install
+  ```
+
+  This will copy all extensions to your local Jupyter installation
+  and configure the extensions to work.  
+  **Note**: The notebook server is not allowed to run during installation.
+
+2. __Installing the Anaconda package__  
+  When using the Anaconda Python distribution (highly recommended), you can install the package using
+
+  ```bash
+  conda install -c https://conda.binstar.org/juhasch nbextensions
+  ```
+
+  Alternatively, you can download the latest master version and do a
+
+  ```bash
+  conda build IPython-notebook-extensions
+  ```
+
+  yourself to build the Anaconda package.
+
+3. __Manual installation__  
+  See below.
+
+
+Manual Installation
+-------------------
+
+1. __Locate your Jupyter config and data directories__
+
+  * To find your __Jupyter data directory__, open ipython and execute the following:
+
+    ```Python
+    from __future__ import print_function
+    from jupyter_core.paths import jupyter_data_dir, jupyter_path
+    print(jupyter_data_dir())
+    print(jupyter_path())
+    ```
+
+    The `jupyter_data_dir()` shows you where *local* extensions and templates can be installed.  
+    The `jupyter_path()` shows you directories which are searched for *globally* installed extensions and templates.
+
+  * To find your __Jupyter config directory__, open ipython and execute the following:
+
+    ```Python
+    from __future__ import print_function
+    from jupyter_core.paths import jupyter_config_dir, jupyter_config_path
+    print(jupyter_config_dir())
+    print(jupyter_config_path())
+    ```
+
+    Similarly to the data directory,  
+    `jupyter_config_dir()` shows you where your *local* configuration files are stored.  
+    `jupyter_config_path()` shows you where Jupyter will look for *global* configuration files.
+
+    For the notebook, there are two files that will be used for configuration:
+    `jupyter_notebook_config.py` and `jupyter_notebook_config.json`.
+    The config is loaded from `jupyter_notebook_config.json`,
+    and then modified according to code in `jupyter_notebook_config.py`.
+
+1. __Install the various components__
+
+  * copy the `nbextensions` folder to your Jupyter data directory (see step 1.)
+  * copy the `extensions` folder to your Jupyter data directory (see step 1.)
+  * copy the `templates` folder to your Jupyter data directory (see step 1.)
+
+3. __Configuration__
+
+  There are two configuration files we need to edit in order to to get the extensions to load correctly once they've been installed.
+  They're both located inside your Jupyter config directory (see step 1.).
+  You may need to create them if they don't already exist.
+
+  <br>
+  1. __Edit your `jupyter_notebook_config.py` file__
+    in your Jupyter config directory (see step 1.)
+    to contain the following lines:
+
+    ```python
     from jupyter_core.paths import jupyter_config_dir, jupyter_data_dir
-    import os
+    import os.path
     import sys
-    
+
     sys.path.append(os.path.join(jupyter_data_dir(), 'extensions'))
-    
+
     c = get_config()
+
     c.NotebookApp.extra_template_paths = [os.path.join(jupyter_data_dir(),'templates') ]
+    c.NotebookApp.server_extensions = ['nbextensions']
+
+    c.Exporter.template_path = [os.path.join(jupyter_data_dir(), 'templates')]
+    c.Exporter.preprocessors = [
+        "pre_codefolding.CodeFoldingPreprocessor",
+        "pre_pymarkdown.PyMarkdownPreprocessor"
+    ]
+
+    c.NbConvertApp.postprocessor_class = "post_embedhtml.EmbedPostProcessor"
     ```
-    And `.jupyter/jupyter_notebook_config.py`
-    ```
+
+  2. __Create/edit your `jupyter_nbconvert_config.py` file__
+    in your Jupyter config directory (see step 1.)
+    to contain the following lines:
+
+    ```Python
     from jupyter_core.paths import jupyter_config_dir, jupyter_data_dir
-    import os
+    import os.path
     import sys
-    
+
     sys.path.append(os.path.join(jupyter_data_dir(), 'extensions'))
-    
+
     c = get_config()
+
     c.Exporter.template_path = [os.path.join(jupyter_data_dir(), 'templates') ]
+    c.Exporter.preprocessors = [
+        "pre_codefolding.CodeFoldingPreprocessor",
+        "pre_pymarkdown.PyMarkdownPreprocessor",
+    ]
+
+    c.NbConvertApp.postprocessor_class = "post_embedhtml.EmbedPostProcessor"
     ```
-    This makes sure the Python extensions are found in the `~/Library/Jupyter/extensions` directory and the 
-    additional templates are found in `~/Library/Jupyter/templates`
 
- 2. Configure the server extension, and pre-/postprocessessors:   
-    Edit the `.jupyter/jupyter_notebook.json` to look like this
-     ```
-     {
-      "Exporter": {
-        "preprocessors": [
-          "pre_codefolding.CodeFoldingPreprocessor",
-          "pre_pymarkdown.PyMarkdownPreprocessor"
-        ]
-      },
-      "NbConvertApp": {
-        "postprocessor_class": "post_embedhtml.EmbedPostProcessor"
-      },
-      "NotebookApp": {
-        "server_extensions": [
-          "nbextensions"
-        ]
-      },
-      "version": 1
-    }
-    ```
- Edit the `.jupyter/jupyter_nbconvert.json` to look like this:
-     ```
-      {
-      "Exporter": {
-        "preprocessors": [
-          "pre_codefolding.CodeFoldingPreprocessor",
-          "pre_pymarkdown.PyMarkdownPreprocessor"
-        ]
-      },
-      "NbConvertApp": {
-        "postprocessor_class": "post_embedhtml.EmbedPostProcessor"
-      },
-      "version": 1
-    }
-    ```
-    This will load the `nbextensions` server extension in the notebook, and add several pre/- and postprocessors that
-     are required by notebook extensions to export notebooks using `jupter nbconvert` 
-     (namely Codefolding, Python Mmarkdown, Runtools).
-     
-     
-    
-3. Help with locating files
----------------------------
+  This should make sure the notebook javascript extensions are found in the correct 'nbextensions' directory,
+  the Python server-side extensions and pre- and post-processors are found in the correct `extensions` directory,
+  and the additional templates are found in the correct `templates` directory.
 
-If you're having problems with where the different files are supposed to go,
-here's an attempt at an explanation.
-Jupyter/IPython 4.x works differently than IPython 3.x:
-
-* The notebook was split from IPython. You need to install both to run the
-  notebook with IPython now.
-  The easiest way is to use Anaconda and do a `conda install jupyter`
-* There are no profiles anymore.
-  You can specify environment variables to change the default, see
-  [Jupyter ML](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!topic/jupyter/7q02jjksvFU).
-* The configuration has moved to a new place. To find out where, see below.
-* There is a kind of automatic upgrade of the configuration files from IPython 3.x to Jupyter.
-
-
-### So where are all the config files now?
-To find where the configuration files are, start IPython and run the following:
-
-```Python
-from __future__ import print_function
-from jupyter_core.paths import jupyter_config_dir, jupyter_config_path
-print(jupyter_config_dir())
-print(jupyter_config_path())
-```
-
-`jupyter_config_dir()` shows you where your *local* configuration files are,
-`jupyter_config_path()` shows you where Jupyter will look for *global* configuration files.
-For the notebook, there are two files that will be used:
-`jupyter_notebook_config.py` and `jupyter_notebook_config.json`.
-
-The `nbextensions` directory has moved to a different location and can be found
-in one of these directories:
-
-```Python
-from __future__ import print_function
-from jupyter_core.paths import jupyter_data_dir, jupyter_path
-print(jupyter_data_dir())
-print(jupyter_path())
-```
+  The server-side extensions are used to:
+  * provide the `nbextensions` server extension in the notebook
+  * add several pre- and post-processors that are required by some notebook
+    extensions to export notebooks using `jupter nbconvert`
+    (namely Codefolding, Python Mmarkdown, Runtools).
 
 
 Internals
@@ -215,10 +218,16 @@ HTML(top + table + bottom)
 If you reload the notebook after enabling a notebook extension, the extension
 should be loaded. You can also check the Javascript console to confirm.
 
+
 YAML file format
 ----------------
-A notebook extensions is found, when a special YAML file describing the extensions is found.
-The YAML file can have any name with the extension `YAML`, and describes the notebook extension. Note that keys (in bold) are case-sensitive.
+
+A notebook extension is detected by the config page when
+a special YAML file describing the extension
+is found in the `nbextensions` directory.
+The YAML file can have any name with the extension `YAML`, and describes the notebook extension.
+The following items can be used in the YAML file.  
+__Note__ that the keys (in bold) are case-sensitive.
 
 * **Type**          - identifier, must be 'IPython Notebook Extension'
 * **Name**          - unique name of the extension
@@ -266,4 +275,27 @@ If an extension doesn't work, here are some ways you can check what is wrong:
    `http://127.0.0.1:8888/nbextensions/usability/runtools/main.js`
 3. Check for error messages in the JavaScript console of the browser.
 4. Check for any error messages in the server output logs
- 
+
+
+Jupyter/IPython 4.x vs IPython 3.x
+----------------------------------
+
+If you're confused about where the different files are supposed to go
+since the switch to Jupyter 4.x,
+here's an attempt at an explanation:
+Jupyter/IPython 4.x works differently than IPython 3.x:
+
+* The notebook was split from IPython. You need to install both to run the
+  notebook with IPython now.
+* There are no profiles anymore.
+  You can specify environment variables to change the default, see
+  [Jupyter ML](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!topic/jupyter/7q02jjksvFU).
+* The configuration has moved to a new place. See above.
+* There is a kind of automatic upgrade of the configuration files from IPython 3.x to Jupyter.
+* The locations above work correctly if you're starting your notebook server with
+  `jupyter notebook`.
+  Note that if you're still trying to use `ipython notebook`, although it may work,
+  it may also result in some of the configuration files being sought in old locations
+  at the same time as others are sought for in the new locations.
+  This can get confusing fast.
+  The simplest solution, if possible, is to switch to the new `jupyter` command!


### PR DESCRIPTION
* switch back to a link to the repository's main readme rather than a relative link, in order to avoid breakage when viewed in rendermd
* clarify some of the manual installation instructions about where to find files
* remove references to editing json config files, in favour of editing the `jupyter_notebook_config.py` and `jupyter_nbconvert_config.py` files
* add github-flavour language specs for code blocks