### PR TITLE
Config/js various updates to config

### DIFF
--- a/nbextensions/config/hotkey_editor.js
+++ b/nbextensions/config/hotkey_editor.js
@@ -1,0 +1,236 @@
+
+define([
+    'underscore',
+    'bootstrap',
+    'jquery',
+    'base/js/dialog',
+    'base/js/utils',
+    'notebook/js/quickhelp',
+    'codemirror/lib/codemirror'
+], function(
+    _,
+    bs,
+    $,
+    dialog,
+    utils,
+    quickhelp,
+    CodeMirror
+){
+    "use strict";
+
+    // patch quickhelp with required definitions
+    var platform = utils.platform;
+    var special_case = { pageup: "PageUp", pagedown: "Page Down", 'minus': '-' };
+    var quickhelp_patch_methods = {
+        prettify : function (s) {
+            s = s.replace(/-$/, 'minus'); // catch shortcuts using '-' key
+            var keys = s.split('-');
+            var k, i;
+            for (i=0; i < keys.length; i++) {
+                k = keys[i];
+                if ( k.length == 1 ) {
+                    keys[i] = "<code><strong>" + k + "</strong></code>";
+                    continue; // leave individual keys lower-cased
+                }
+                if (k.indexOf(',') === -1){
+                    keys[i] = ( special_case[k] ? special_case[k] : k.charAt(0).toUpperCase() + k.slice(1) );
+                }
+                keys[i] = "<code><strong>" + keys[i] + "</strong></code>";
+            }
+            return keys.join('-');
+        },
+
+        humanize_sequence : function(sequence) {
+            var joinchar = ',';
+            var hum = _.map(sequence.replace(/meta/g, 'cmd').split(','), this.humanize_shortcut).join(joinchar);
+            return hum;
+        },
+
+        humanize_shortcut : function(shortcut) {
+            var joinchar = '-';
+            if (platform === 'MacOS'){
+                joinchar = '';
+            }
+            var sh = _.map(shortcut.split('-'), this.humanize_key ).join(joinchar);
+            return sh;
+        }
+    };
+    for (var method_name in quickhelp_patch_methods) {
+        if (!quickhelp.hasOwnProperty(method_name)) {
+            quickhelp[method_name] = quickhelp_patch_methods[method_name];
+        }
+    }
+
+    /**
+     * @param keyname a keyname as normalized by normalizeKeyName
+     * returns
+     * - true for valid
+     * - false for unrecognised/invalid
+     * - undefined for incomplete
+     */
+    var validate_keyname = function(keyname, invalid_hotkeynames, incomplete_hotkeynames) {
+        if (keyname === false) return false;
+        if (invalid_hotkeynames === undefined) {
+            invalid_hotkeynames = ['Esc', 'Cmd-R', 'Cmd-N'];
+        }
+        if (invalid_hotkeynames.indexOf(keyname) >= 0) return false;
+        if (incomplete_hotkeynames === undefined) {
+            incomplete_hotkeynames = [
+                'Cmd', 'Ctrl', 'Alt', 'Shift', 'Cmd-Mod', 'Meta'
+            ];
+        }
+        if (incomplete_hotkeynames.indexOf(keyname) >= 0) return undefined;
+        return true;
+    };
+
+
+    /**
+     * Pass it an option dictionary with the following properties:
+     * - keyname
+     * - title
+     * - description
+     * - default
+     * - on_successful_close
+     * - invalid_hotkeynames
+     * - incomplete_hotkeynames
+     */
+    var HotkeyEditor = function(options) {
+
+        // add a global style to get rid of bg on our pretty-printed code tags
+        if ($('style#hotkey-editor-styles').length < 1) {
+            $('html > head').append(
+                $('<style id="hotkey-editor-styles"/>').html(
+                    '#hotkey_editor_input_group code { background: transparent; }'
+                )
+            );
+        }
+
+        options = options || {};
+        var keyname = options.keyname || '';
+        var title = options.title || '';
+
+        var input = $('<div class="input-group" id="hotkey_editor_input_group"/>');
+
+        var btn = $('<a/>', {
+            type: 'button',
+            class: "btn btn-default hotkey-editor-capture-btn",
+            'data-toggle': "button",
+            'value': 'OFF'
+        }).css('border-right', 'none').text('Capture');
+
+        var textcontrol = $('<input/>', {
+            type: 'text',
+            class: "form-control hotkey-editor-text-input",
+            placeholder: "type a key-combination, or click button & press one"
+        }).val(keyname).on('change', function (event) {
+            $(this).nextAll('.input-group-addon').html(
+                quickhelp.prettify(quickhelp.humanize_shortcut($(this).val()))
+            );
+        });
+
+        // http://jsfiddle.net/amma0py3/
+        input.append($('<div class="input-group-btn"/>').append(btn));
+        input.append(textcontrol);
+
+        // feedback icon
+        input.append(
+            $('<span class="form-control-feedback"/>').css('right', '80px')
+                .append($('<i class="fa fa-lg"/>'))
+        );
+
+        // pretty-display hotkey
+        input.append(
+            $('<div class="input-group-addon"/>').css('width', '80px').css(
+                platform === 'MacOS' ?  {'letter-spacing': '1px'} : {}
+            )
+        );
+
+        var set_validation_status = function (valid) {
+            var form_group = textcontrol.closest('.form-group');
+            var form_fdbck = form_group.find('i');
+            var ok_button = $('.modal-footer button').first();
+
+            if (valid === true) {  // valid
+                form_group.removeClass('has-error has-warning').addClass('has-success');
+                form_fdbck.removeClass('fa-remove fa-ellipsis-h').addClass('fa-check');
+                ok_button.prop('disabled', false);
+                return false;
+            }
+            if (valid === false) {  // invalid
+                form_group.removeClass('has-success has-warning').addClass('has-error');
+                form_fdbck.removeClass('fa-check fa-ellipsis-h').addClass('fa-remove');
+            }
+            else {  // not invalid, but incomplete
+                form_group.removeClass('has-error has-success').addClass('has-warning');
+                form_fdbck.removeClass('fa-check fa-remove').addClass('fa-ellipsis-h');
+            }
+            $('.modal-footer button').first().prop('disabled', true);
+        };
+
+
+        var key_capture_callback = function(event) {
+            var keyname = CodeMirror.keyName(event);
+            if (keyname === false)   //unrecognised
+                textcontrol.val(
+                    "Sorry, but I can't interpret that combo " +
+                    "\u2639 \u2192 ");
+            else {
+                if (keyname !== 'Esc') textcontrol.val(keyname).change();
+            }
+            var valid = validate_keyname(keyname, options.invalid_hotkeynames,
+                                         options.incomplete_hotkeynames);
+
+            if (keyname !== 'Esc') set_validation_status(valid);
+            return valid === false ? true : false; // allow invalid hotkeys to propagate
+        };
+
+        var stop_key_capture = function(event) {
+            input.off('keydown');
+            btn.removeClass('capturing').text('Capture');
+            setTimeout(function(){ btn.blur(); }, 100);
+        };
+
+        var start_key_capture = function(event){
+            textcontrol.focus();
+            input.on('keydown', key_capture_callback);
+            btn.addClass('capturing').text('Press your combo now!');
+        };
+
+        btn.on('click', function(event) {
+            if (btn.hasClass('capturing')) stop_key_capture();
+            else start_key_capture();
+            return true;
+        });
+
+        input.on('blur', stop_key_capture);
+
+        var body = $('<div class="form-group has-feedback"/>').append(
+            $('<label/>').attr("for", "hotkey_editor_input_group").text(title)
+        ).append(input);
+
+        return dialog.modal({
+            title: "Edit Hotkey",
+            body: body,
+            buttons : {
+                "OK": {
+                    class: "btn-primary",
+                    click: function () {
+                        if (options.on_successful_close) {
+                            options.on_successful_close(textcontrol.val());
+                        }
+                    }
+                },
+                "Cancel": {}
+            },
+            open : function () {
+                $(this).find('.hotkey-editor-capture-btn').click();
+            }
+        });
+    };
+
+    return {
+        HotkeyEditor : HotkeyEditor,
+        validate_keyname : validate_keyname,
+        humanize_shortcut : quickhelp.humanize_shortcut
+    };
+});

--- a/nbextensions/config/main.css
+++ b/nbextensions/config/main.css
@@ -1,11 +1,9 @@
-#nbext-container {
-    padding: 0 15px 15px;
-    -moz-box-shadow: 0 0 12px 1px rgba(87, 87, 87, 0.2);
-    -webkit-box-shadow: 0 0 12px 1px rgba(87, 87, 87, 0.2);
-    box-shadow: 0 0 12px 1px rgba(87, 87, 87, 0.2);
-    min-height: calc(100% - 15px);
+#site > .container {
+    padding-top: 0;
 }
 
+/* nbext-page-title-wrap and nbext-page-title
+   are styled to match the notebook save widget */
 .nbext-page-title-wrap {
     margin-top: 6px;
 }
@@ -27,14 +25,14 @@
     clear: both;
 }
 
-.nbext-row {
-    padding: 1em;
+#site > .container > .row {
+    padding: 15px;
     display: flex;
     flex-direction: row;
     align-items: center;
 }
 
-.nbext-row + .nbext-row {
+#site > .container > .row + .row {
     border-top: 1px solid #AAA;
 }
 
@@ -68,66 +66,15 @@
     max-width: 100%;
 }
 
+.nbext-desc,
+.nbext-compat,
+.nbext-activate-btns,
 .nbext-params {
-    margin-top: 8px;
-    border: 1px solid #cccccc;
-    border-radius: 4px;
-    padding: 45px 15px 0;
-    position: relative;
+    margin-bottom: 8px;
 }
 
-.nbext-params:before {
-    position: absolute;
-    top: 15px;
-    left: 15px;
-    font-size: 17px;
-    font-weight: 500;
-    color: #888888;
-    content: "Parameters";
-}
-
-.nbext-param {
-    display: block;
-    width: 100%;
-    padding: 8px;
-    border: 1px solid #cccccc;
-    border-radius: 4px;
-    -moz-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
-    -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
-    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
-    -moz-transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
-    -webkit-transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
-    -o-transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
-    transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
-}
-
-.nbext-param:first-child:not(:last-child) {
-    border-bottom-right-radius: 0;
-    border-top-right-radius: 0;
-}
-
-.nbext-param:last-child:not(:first-child) {
-    border-bottom-left-radius: 0;
-    border-top-left-radius: 0;
-}
-
-.nbext-param + .nbext-param {
-    border-top: none;
-}
-
-.nbext-param-name {
-    font-size: 120%;
-}
-
-.nbext-list-wrap {
-    height: auto;
-}
-
-.nbext-list {
-    margin-bottom: 0;
-    list-style-type: none;
-    -moz-padding-start: 0;
-    -webkit-padding-start: 0;
+.nbext-params > .panel-heading {
+    font-size: 110%;
 }
 
 .nbext-list-element,
@@ -152,12 +99,6 @@
     border-bottom-left-radius: 2px;
 }
 
-.nbext-list-btn-add {
-    border-radius: 2px;
-    border: 1px solid #cccccc;
-}
-
-.nbext-list-element:first-child .nbext-list-el-btn-up,
-.nbext-list-element:last-child .nbext-list-el-btn-down {
-    display: none;
+.input-group .nbext-list-btn-add {
+    font-size: inherit;
 }

--- a/nbextensions/config/main.css
+++ b/nbextensions/config/main.css
@@ -1,31 +1,9 @@
-
-#render-container,
 #nbext-container {
-	padding: 15px;
-    padding-top: 0;
+    padding: 0 15px 15px;
     -moz-box-shadow: 0 0 12px 1px rgba(87, 87, 87, 0.2);
     -webkit-box-shadow: 0 0 12px 1px rgba(87, 87, 87, 0.2);
     box-shadow: 0 0 12px 1px rgba(87, 87, 87, 0.2);
     min-height: calc(100% - 15px);
-}
-
-#render-container.text-danger {
-    padding-top: 15px;
-}
-
-#render-container pre {
-  background-color: #f5f5f5;
-  padding: 8.5px;
-}
-
-#render-container code {
-  background-color: #f9f2f4;
-  padding: 2px 4px;
-}
-
-#render-container pre code {
-    background-color: transparent;
-    padding: 0;
 }
 
 .nbext-page-title-wrap {
@@ -49,13 +27,11 @@
     clear: both;
 }
 
-
 .nbext-row {
     padding: 1em;
     display: flex;
     flex-direction: row;
     align-items: center;
-
 }
 
 .nbext-row + .nbext-row {
@@ -67,28 +43,18 @@
 }
 
 .nbext-compat-true {
-	color: green;
+    color: green;
 }
 
 .nbext-compat-false {
     color: red;
 }
 
-.nbext-activate-btns button {
-    border-radius: 0;
+.nbext-activate-btns .btn {
+    border-radius: 4px;
 }
 
-.nbext-activate-btns button:first-child {
-    border-top-left-radius: 4px;
-    border-bottom-left-radius: 4px;
-}
-
-.nbext-activate-btns button:last-child {
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
-}
-
-.nbext-activate-btns button[disabled] {
+.nbext-activate-btns .btn[disabled] {
     color: #cccccc;
 }
 
@@ -125,7 +91,7 @@
     width: 100%;
     padding: 8px;
     border: 1px solid #cccccc;
-    border-radius: 0;
+    border-radius: 4px;
     -moz-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
     -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
     box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
@@ -135,14 +101,14 @@
     transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
 }
 
-.nbext-param:first-child {
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px;
+.nbext-param:first-child:not(:last-child) {
+    border-bottom-right-radius: 0;
+    border-top-right-radius: 0;
 }
 
-.nbext-param:last-child {
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+.nbext-param:last-child:not(:first-child) {
+    border-bottom-left-radius: 0;
+    border-top-left-radius: 0;
 }
 
 .nbext-param + .nbext-param {
@@ -178,7 +144,7 @@
 }
 
 .nbext-list-element:only-child > .handle {
-    display: none
+    display: none;
 }
 
 .nbext-list-element:only-child > .handle + .form-control {
@@ -186,19 +152,11 @@
     border-bottom-left-radius: 2px;
 }
 
-a.input-group-addon.nbext-list-btn-add {
+.nbext-list-btn-add {
     border-radius: 2px;
     border: 1px solid #cccccc;
 }
 
-/*.nbext-list-element input {
-    flex: 1;
-}
-*/
-/*.nbext-list-element a {
-    flex: 0;
-}
-*/
 .nbext-list-element:first-child .nbext-list-el-btn-up,
 .nbext-list-element:last-child .nbext-list-el-btn-down {
     display: none;

--- a/nbextensions/config/main.css
+++ b/nbextensions/config/main.css
@@ -13,31 +13,19 @@
     padding-top: 15px;
 }
 
-#render-container img {
-  margin-top: 1em;
-  margin-bottom: 1em;
-  margin-left: auto;
-  margin-right: auto;
-}
-
-#render-container img,
-#render-container svg {
-  max-width: 100%;
-  height: auto;
-}
-
-#render-container img.unconfined,
-#render-container svg.unconfined {
-  max-width: none;
-}
-
 #render-container pre {
-  padding: 0.25em 0.5em 0.25em;
-  margin: 0.5em 0 0.5em;
+  background-color: #f5f5f5;
+  padding: 8.5px;
 }
 
 #render-container code {
-  font-size: 100%;
+  background-color: #f9f2f4;
+  padding: 2px 4px;
+}
+
+#render-container pre code {
+    background-color: transparent;
+    padding: 0;
 }
 
 .nbext-page-title-wrap {

--- a/nbextensions/config/main.js
+++ b/nbextensions/config/main.js
@@ -95,8 +95,11 @@ require([
      * Handle button click event to activate/deactivate extension
      */
     var handle_buttons_click = function(evt) {
-        var ext_id = this.id.replace(/-on|-off/, '');
-        var state = (this.id.search(/-on/) >= 0) ? true : false;
+        // endswith
+        var suffix = '-on';
+        var state = this.id.indexOf(suffix, this.id.length - suffix.length) !== -1;
+        var end = this.id.length - suffix.length - Number(!state);
+        var ext_id = this.id.substring(0, end);
         set_buttons_active(ext_id, state);
         set_config_active(ext_id, state);
     };

--- a/nbextensions/config/main.js
+++ b/nbextensions/config/main.js
@@ -307,7 +307,7 @@ require([
      * extension with the given id.
      */
     var build_activate_buttons = function(ext_id) {
-        var div_buttons = $('<div class="nbext-activate-btns"/>');
+        var div_buttons = $('<div class="btn-group nbext-activate-btns"/>');
 
         var btn_activate = $('<button/>', {
             'type': 'button',

--- a/nbextensions/config/render.js
+++ b/nbextensions/config/render.js
@@ -58,6 +58,6 @@ define([
         document.getElementsByTagName("head")[0].appendChild(link);
     };
 
-    add_css('./main.css');
+    add_css('./rendermd.css');
     page.show();
 });

--- a/nbextensions/config/rendermd.css
+++ b/nbextensions/config/rendermd.css
@@ -1,14 +1,16 @@
 /* CSS overrides for the rendermd page */
 
+/* the render container should match the notebook container*/
 #render-container {
   padding: 15px;
-  padding-top: 0;
   -moz-box-shadow: 0 0 12px 1px rgba(87, 87, 87, 0.2);
   -webkit-box-shadow: 0 0 12px 1px rgba(87, 87, 87, 0.2);
   box-shadow: 0 0 12px 1px rgba(87, 87, 87, 0.2);
-  min-height: calc(100% - 15px);
+  min-height: calc(100% - 30px);
 }
 
+/* rendermd-page-title-wrap and rendermd-page-title
+   are styled to match the notebook save widget */
 .rendermd-page-title-wrap {
     margin-top: 6px;
 }
@@ -21,10 +23,6 @@
     border: none;
     font-size: 146.5%;
     border-radius: 2px;
-}
-
-#render-container.text-danger {
-  padding-top: 15px;
 }
 
 #render-container pre {

--- a/nbextensions/config/rendermd.css
+++ b/nbextensions/config/rendermd.css
@@ -1,0 +1,54 @@
+/* CSS overrides for the rendermd page */
+
+#render-container {
+  padding: 15px;
+  padding-top: 0;
+  -moz-box-shadow: 0 0 12px 1px rgba(87, 87, 87, 0.2);
+  -webkit-box-shadow: 0 0 12px 1px rgba(87, 87, 87, 0.2);
+  box-shadow: 0 0 12px 1px rgba(87, 87, 87, 0.2);
+  min-height: calc(100% - 15px);
+}
+
+.rendermd-page-title-wrap {
+    margin-top: 6px;
+}
+
+.rendermd-page-title {
+    height: 1em;
+    line-height: 1em;
+    padding: 3px;
+    margin-left: 16px;
+    border: none;
+    font-size: 146.5%;
+    border-radius: 2px;
+}
+
+#render-container.text-danger {
+  padding-top: 15px;
+}
+
+#render-container pre {
+  background-color: #f5f5f5;
+  padding: 4px;
+}
+
+#render-container code {
+  background-color: #f9f2f4;
+  padding: 2px 4px;
+}
+
+#render-container pre code {
+  background-color: transparent;
+  padding: 0;
+}
+
+.rendered_html ol li,
+.rendered_html ul li {
+  margin-bottom: 0.5em;
+}
+
+.rendered_html iframe {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}

--- a/nbextensions/usability/codefolding/codefolding.yaml
+++ b/nbextensions/usability/codefolding/codefolding.yaml
@@ -7,4 +7,6 @@ Main: main.js
 Compatibility: 4.x
 Parameters:
 - name: codefolding_hotkey
-  description: Hotkey to fold/unfold code, e.g. 'Alt-F'
+  description: Hotkey to fold/unfold code
+  input_type: hotkey
+  default: Alt-F

--- a/templates/nbextensions.html
+++ b/templates/nbextensions.html
@@ -35,7 +35,7 @@ data-extension-list='{{extension_list}}'
 
 {% block site %}
 
-<div id="nbext-container" class="container"></div>
+<div id="notebook-container" class="container"></div>
 
 {% endblock %}
 

--- a/templates/nbextensions.html
+++ b/templates/nbextensions.html
@@ -18,7 +18,7 @@ data-extension-list='{{extension_list}}'
 <div class="pull-left nbext-page-title-wrap">
 	<span class="nbext-page-title" style="display: none;">
 		Configuration for Notebook Extensions
-		(<a href="/nbextensions/config/rendermd/nbextensions/config/readme.md">more Information</a>)
+		(<a href="/nbextensions/config/rendermd/nbextensions/config/readme.md">more information</a>)
 	</span>
 </div>
 <div class="nbext-showhide-incompat" style="display: none;">

--- a/templates/rendermd.html
+++ b/templates/rendermd.html
@@ -15,8 +15,8 @@ data-md-url='{{md_url}}'
 
 {% block headercontainer %}
 
-<div class="pull-left nbext-page-title-wrap">
-	<span class="nbext-page-title">{{ page_title }}</span>
+<div class="pull-left rendermd-page-title-wrap">
+	<span class="rendermd-page-title">{{ page_title }}</span>
 </div>
 
 {% endblock %}

--- a/templates/rendermd.html
+++ b/templates/rendermd.html
@@ -27,10 +27,8 @@ data-md-url='{{md_url}}'
 
 {% block site %}
 
-{# we could make everything look like notebook-formatted markdown cells by
-adding the "rendered_html" class, but it doesn't look so good for full-page
-readme files, so for now I haven't bothered #}
-<div id="render-container" class="container"></div>
+{# the "rendered_html" class, will make everything look like notebook-formatted markdown cells. The custom css loaded by render.js is used to add backgrounds for <code> and <pre> blocks and snippets #}
+<div id="render-container" class="container rendered_html"></div>
 
 {% endblock %}
 


### PR DESCRIPTION
* add support for editable hotkeys as extension parameters
* make activation/deactivtion more robust (was breaking for extensions containing `-on` in the name, like `read-only`
* fix `nbextensions.html` template to use the new rendermd url
* improve rendering of markdown readmes to better match notebook markdown cells
* simplify config CSS by making more use of bootstrap classes
* split rendermd CSS overrides from main config CSS
* fix padding, add comments in rendermd CSS