### PR TITLE
fix YAML file for `usability/limit-output`…

### DIFF
--- a/nbextensions/usability/limit_output/limit-output.yaml
+++ b/nbextensions/usability/limit_output/limit-output.yaml
@@ -15,4 +15,4 @@ Parameters:
 - name: limit_output_message
   description: Message to append when output is limited
   input_type: text
-  default: **OUTPUT MUTED**
+  default: '**OUTPUT MUTED**'


### PR DESCRIPTION
… since starting a YAML scalar with a special character ('*') can cause some versions of the python `yaml` module to baulk (although others seem ok with it, as long as there are two, so I didn't notice this on my version). See #368 for details.