### PR TITLE
Added move_selected_cells extension

### DIFF
--- a/nbextensions/usability/move_selected_cells/README.md
+++ b/nbextensions/usability/move_selected_cells/README.md
@@ -5,7 +5,7 @@ This is a quick (and dirty) extension - move up or down several selected cell*s*
 
 It is a bit dirty because it would be better to act on DOM elements and write a correct move_cells() function. 
 
-Cautionary note: It is very probable that such functionality will be available shortly in the official Jupyter notebook. But in the meantime, it could be useful to some people. moving cells or series of cells via simple keystrokes is super useful
+Cautionary note: It is very probable that such functionality will be available shortly in the official Jupyter notebook. But in the meantime, it could be useful to some people. 
 
 Keyboard shortcuts: *Alt-up* and *Alt-down* (works also with single cells!)
 

--- a/nbextensions/usability/move_selected_cells/README.md
+++ b/nbextensions/usability/move_selected_cells/README.md
@@ -1,9 +1,11 @@
 ## Move selected cells
 
-This is a quick (and dirty) extension - move up or down several selected cell*s*
+This is a quick (and dirty) extension - move up or down several selected cell*s*. Moving cells or series of cells via simple keystrokes can be super useful.
 
-It is a bit dirty because it would be better to act on DOM elements and write a correct move_cells() function. This will come. 
-In the meantime, moving cells or series of cells via simple keystrokes is super useful
+
+It is a bit dirty because it would be better to act on DOM elements and write a correct move_cells() function. 
+
+Cautionary note: It is very probable that such functionality will be available shortly in the official Jupyter notebook. But in the meantime, it could be useful to some people. moving cells or series of cells via simple keystrokes is super useful
 
 Keyboard shortcuts: *Alt-up* and *Alt-down* (works also with single cells!)
 

--- a/nbextensions/usability/move_selected_cells/README.md
+++ b/nbextensions/usability/move_selected_cells/README.md
@@ -1,0 +1,10 @@
+## Move selected cells
+
+This is a quick (and dirty) extension - move up or down several selected cell*s*
+
+It is a bit dirty because it would be better to act on DOM elements and write a correct move_cells() function. This will come. 
+In the meantime, moving cells or series of cells via simple keystrokes is super useful
+
+Keyboard shortcuts: *Alt-up* and *Alt-down* (works also with single cells!)
+
+**Cell selection**: Cells can be selected using the rubberband (required extension) or via Shift-J and Shift-K

--- a/nbextensions/usability/move_selected_cells/exercise.yaml
+++ b/nbextensions/usability/move_selected_cells/exercise.yaml
@@ -1,0 +1,7 @@
+Type: IPython Notebook Extension
+Name: Exercise
+Description: Exercise TEST
+Link: https://github.com/ipython-contrib/IPython-notebook-extensions/wiki/
+Icon: icon.png
+Main: main.js
+Compatibility: 3.x

--- a/nbextensions/usability/move_selected_cells/exercise.yaml
+++ b/nbextensions/usability/move_selected_cells/exercise.yaml
@@ -1,7 +1,0 @@
-Type: IPython Notebook Extension
-Name: Exercise
-Description: Exercise TEST
-Link: https://github.com/ipython-contrib/IPython-notebook-extensions/wiki/
-Icon: icon.png
-Main: main.js
-Compatibility: 3.x

--- a/nbextensions/usability/move_selected_cells/main.js
+++ b/nbextensions/usability/move_selected_cells/main.js
@@ -27,7 +27,7 @@ var add_cmd_shortcuts = {
             if (ss[0] + 1 < ncells) {
                 for (var k in ss) {
                     IPython.notebook.move_cell_down(ss[k]);
-                };
+                }; //The second loop is needed because move_cell deselect
                 for (var k in ss) {
                     IPython.notebook.get_cell(ss[k] + 1).select();
                 }

--- a/nbextensions/usability/move_selected_cells/main.js
+++ b/nbextensions/usability/move_selected_cells/main.js
@@ -1,0 +1,68 @@
+// Copyright (c) IPython-Contrib Team.
+// Distributed under the terms of the Modified BSD License.
+
+// This is a quick (and dirty) extension - move up or down several selected cells
+// Dirty because it would be better to act on dom elements and write a correct move_cells() function
+// Keyboard shortcuts: Alt-up and Alt-down (works with single cells also -- this is useful!)
+// Cells can be selected using the rubberband or via Shift-J and Shift-K
+
+
+define([
+    'base/js/namespace',
+    'jquery',
+    'require',
+    'base/js/events',
+    'nbextensions/usability/rubberband/main'
+], function(IPython, $, require, events, rubberband) {
+    "use strict";
+var add_cmd_shortcuts = {
+    'Alt-down': {
+        help: 'Move selected cells down',
+        help_index: 'ht',
+        handler: function(event) {
+            var ncells = IPython.notebook.ncells();
+            var s = IPython.notebook.get_selected_indices();
+            //ensure cells indices are reverse sorted
+            var ss = s.sort(function(x, y) {return x - y}).reverse(); 
+            if (ss[0] + 1 < ncells) {
+                for (var k in ss) {
+                    IPython.notebook.move_cell_down(ss[k]);
+                };
+                for (var k in ss) {
+                    IPython.notebook.get_cell(ss[k] + 1).select();
+                }
+            }
+        }
+    },
+    'Alt-up': {
+        help: 'Move selected cells up',
+        help_index: 'ht',
+        handler: function(event) {
+            var s = IPython.notebook.get_selected_indices();
+            //ensure cells indices are sorted 
+            var ss = s.sort(function(x, y) {return x - y});
+            if (ss[0] - 1 >= 0) {
+                for (var k in ss) {
+                    IPython.notebook.move_cell_up(ss[k]);
+                };
+                for (var k in ss) {
+                    IPython.notebook.get_cell(ss[k] - 1).select();
+                }
+            }
+        }
+    }
+}
+
+
+IPython.keyboard_manager.command_shortcuts.add_shortcuts(add_cmd_shortcuts);
+
+function load_ipython_extension(){
+    //console.log("Executing rubberband load_ipython");
+    rubberband.load_ipython_extension();
+}
+
+    return {
+        load_ipython_extension: load_ipython_extension,
+    };
+    
+});

--- a/nbextensions/usability/move_selected_cells/move_selected_cells.yaml
+++ b/nbextensions/usability/move_selected_cells/move_selected_cells.yaml
@@ -1,0 +1,7 @@
+Type: IPython Notebook Extension
+Name: Move selected cells
+Description: Move selected cell*s* using keybaord shortcuts Alt-up and Alt-down
+Link: https://github.com/ipython-contrib/IPython-notebook-extensions/wiki/
+Icon: 
+Main: main.js
+Compatibility: 4.x

--- a/nbextensions/usability/move_selected_cells/move_selected_cells.yaml
+++ b/nbextensions/usability/move_selected_cells/move_selected_cells.yaml
@@ -1,7 +1,7 @@
 Type: IPython Notebook Extension
 Name: Move selected cells
 Description: Move selected cell*s* using keybaord shortcuts Alt-up and Alt-down
-Link: https://github.com/ipython-contrib/IPython-notebook-extensions/wiki/
+Link: README.md 
 Icon: 
 Main: main.js
 Compatibility: 4.x


### PR DESCRIPTION
I found myself this afternoon facing the problem of moving many cells from a part of a notebook to another part of the same notebook. Since I am still in vacations :) and since I learned previously about multicells selection, I got the idea of this quick extension. Clearly, this kind of thing will be probably integrated shortly in the mainstream. But in the meantime, it could be useful to some people.

## Move selected cells

This is a quick (and dirty) extension - **move up or down several selected cells**

It is a bit dirty because it would be better to act on DOM elements and write a correct move_cells() function. In the meantime, moving cells or series of cells via simple keystrokes is super useful

Keyboard shortcuts: *Alt-up* and *Alt-down* (works also with single cells!)

**Cells selection**: Cells can be selected using the `rubberband` (which is a requirement here) or via Shift-J and Shift-K