### PR TITLE
Fix pyyaml requirement

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - nbformat
     - python
     - traitlets
-    - yaml
+    - pyyaml
 
 about:
   home: https://github.com/ipython-contrib/IPython-notebook-extensions


### PR DESCRIPTION
The correct python package name is `pyyaml`. Anaconda also provides a `yaml` package, but that seems to provide Linux/Mac-only binaries, rather than python bindings.