### PR TITLE
future-proofing for extensions using the actions framework

### DIFF
--- a/nbextensions/usability/autoscroll/main.js
+++ b/nbextensions/usability/autoscroll/main.js
@@ -14,6 +14,7 @@ define([
     "use strict";
 
     var prev_threshold = 0;
+    var action_full_name; // will be set when registering the action
 
     // define default values for config parameters
     var params = {
@@ -48,7 +49,7 @@ define([
 
         $('#autoscroll_selector').val(oa.OutputArea.auto_scroll_threshold);
 
-        $('.btn[data-jupyter-action="auto.toggle-output-autoscroll"]')
+        $('.btn[data-jupyter-action="' + action_full_name + '"]')
             .toggleClass('active', oa.OutputArea.auto_scroll_threshold <= 0)
             .blur();
     };
@@ -71,7 +72,7 @@ define([
                 .addClass("form-control select-xs");
             select.change(function() {
                 oa.OutputArea.auto_scroll_threshold = parseInt($(this).val(), 10);
-                $('.btn[data-jupyter-action="auto.toggle-output-autoscroll"]')
+                $('.btn[data-jupyter-action="' + action_full_name + '"]')
                     .toggleClass('active', oa.OutputArea.auto_scroll_threshold <= 0);
                 $(this).blur();
             });
@@ -88,7 +89,7 @@ define([
         }
 
         if (params.autoscroll_show_button) {
-            IPython.toolbar.add_buttons_group(['auto.toggle-output-autoscroll']);
+            IPython.toolbar.add_buttons_group([action_full_name]);
         }
     });
 
@@ -102,7 +103,7 @@ define([
             handler : toggle_output_autoscroll
         };
 
-        IPython.notebook.keyboard_manager.actions.register(action, action_name, prefix);
+        action_full_name = IPython.keyboard_manager.actions.register(action, action_name, prefix);
 
         config.load();
     };

--- a/nbextensions/usability/comment-uncomment/main.js
+++ b/nbextensions/usability/comment-uncomment/main.js
@@ -33,9 +33,21 @@ define([
         // update defaults
         update_params();
 
+        // register actions with ActionHandler instance
+        var prefix = 'auto';
+        var name = 'toggle-comment';
+        var action = {
+            icon: 'fa-comment-o',
+            help    : 'Toggle comments',
+            help_index : 'eb',
+            id : 'read_only_codecell',
+            handler : toggle_comment
+        };
+        var action_full_name = IPython.keyboard_manager.actions.register(action, name, prefix);
+
         // define keyboard shortcuts
         var edit_mode_shortcuts = {};
-        edit_mode_shortcuts[params.comment_uncomment_keybinding] = 'auto.toggle-comment';
+        edit_mode_shortcuts[params.comment_uncomment_keybinding] = action_full_name;
 
         // register keyboard shortcuts with keyboard_manager
         IPython.notebook.keyboard_manager.edit_shortcuts.add_shortcuts(edit_mode_shortcuts);
@@ -49,18 +61,6 @@ define([
     };
 
     var load_ipython_extension = function () {
-        // register actions with ActionHandler instance
-        var prefix = 'auto';
-        var name = 'toggle-comment';
-        var action = {
-            icon: 'fa-comment-o',
-            help    : 'Toggle comments',
-            help_index : 'eb',
-            id : 'read_only_codecell',
-            handler : toggle_comment
-        };
-        IPython.notebook.keyboard_manager.actions.register(action, name, prefix);
-
         // load config to trigger keybinding registration
         config.load();
     };

--- a/nbextensions/usability/init_cell/main.js
+++ b/nbextensions/usability/init_cell/main.js
@@ -45,9 +45,9 @@ define([
             help_index : 'zz',
             handler : run_init_cells
         };
-        IPython.notebook.keyboard_manager.actions.register(action, action_name, prefix);
+        var action_full_name = IPython.notebook.keyboard_manager.actions.register(action, action_name, prefix);
 
-        IPython.toolbar.add_buttons_group([prefix + '.' + action_name]);
+        IPython.toolbar.add_buttons_group([action_full_name]);
 
         // Register a callback to create a UI element for a cell toolbar.
         ctb.register_callback('init_cell.is_init_cell', init_cell_ui_callback, 'code');

--- a/nbextensions/usability/toggle_all_line_numbers/main.js
+++ b/nbextensions/usability/toggle_all_line_numbers/main.js
@@ -42,20 +42,27 @@ define([
         }
     };
 
-    // define actions
-    var toggle_all_linenumbers_actions = {
-        'toggle-all-line-numbers' : {
-            icon: 'fa-sort-numeric-asc',
-            help: 'Toggle linenumbers in all codecells',
-            help_index : 'zz',
-            id: 'toggle_all_linenumbers',
-            handler : toggle_all
-        }
+    // define action, register with ActionHandler instance
+    prefix = prefix || 'auto';
+    var action_name = 'toggle-all-line-numbers';
+    var action = {
+        icon: 'fa-sort-numeric-asc',
+        help: 'Toggle linenumbers in all codecells',
+        help_index : 'zz',
+        id: 'toggle_all_linenumbers',
+        handler: toggle_all
     };
+    var action_full_name; // will be set on registration
 
     config.loaded.then(function() {
         // update default config vals with the newly loaded ones
         update_params();
+
+        // register actions with ActionHandler instance
+        action_full_name = IPython.keyboard_manager.actions.register(action, action_name, prefix);
+
+        // create toolbar button
+        IPython.toolbar.add_buttons_group([action_full_name]);
 
         // (maybe) define hotkey
         if (params.toggle_all_linenumbers_enable_hotkey &&
@@ -65,36 +72,13 @@ define([
                         params.toggle_all_linenumbers_hotkey);
 
             IPython.keyboard_manager.edit_shortcuts.add_shortcut(
-                params.toggle_all_linenumbers_hotkey, 'auto.toggle-all-line-numbers');
+                params.toggle_all_linenumbers_hotkey, action_full_name);
             IPython.keyboard_manager.command_shortcuts.add_shortcut(
-                params.toggle_all_linenumbers_hotkey, 'auto.toggle-all-line-numbers');
+                params.toggle_all_linenumbers_hotkey, action_full_name);
         }
     });
 
-    var register_actions = function(actions, prefix) {
-        prefix = prefix || 'auto';
-        for (var name in actions) {
-            if (actions.hasOwnProperty(name)) {
-                IPython.notebook.keyboard_manager.actions.register(
-                    actions[name], name, prefix
-                );
-            }
-        }
-    };
-
     var load_ipython_extension = function() {
-
-        // register actions with ActionHandler instance
-        register_actions(toggle_all_linenumbers_actions);
-
-        // create toolbar button
-        IPython.toolbar.add_buttons_group([{
-            id: 'toggle_all_linenumbers',
-            label: 'toggle all line numbers',
-            icon: 'fa-sort-numeric-asc',
-            callback: toggle_all
-        }]);
-
         config.load();
     };
 

--- a/nbextensions/usability/toggle_all_line_numbers/main.js
+++ b/nbextensions/usability/toggle_all_line_numbers/main.js
@@ -43,7 +43,7 @@ define([
     };
 
     // define action, register with ActionHandler instance
-    prefix = prefix || 'auto';
+    var prefix = 'auto';
     var action_name = 'toggle-all-line-numbers';
     var action = {
         icon: 'fa-sort-numeric-asc',


### PR DESCRIPTION
The jupyter actions framework altered the character used to join the prefix to the action name from a period to a colon somewhere between 4.0.5 and 4.0.6, in commit 7df94eb0013f9990b85c380e453728b8c18a38ca.
This commit replaces code which was using hard-coded periods to construct full action names for things like buttons with code which uses the full action name which is returned by the action registration call.