### PR TITLE
Config/main

### DIFF
--- a/nbextensions/config/main.css
+++ b/nbextensions/config/main.css
@@ -15,9 +15,10 @@
 }
 
 .nbext-showhide-incompat {
-    margin: 1em 0.5em 0.5em;
-    float: left;
-    clear: both;
+    padding-bottom: 0.5em;
+    /* the selector is hidden by default, revealed by js if any incompatible
+       extensions are found */
+    display: none;
 }
 
 /* styles for the extension-selector nav links */

--- a/nbextensions/config/main.css
+++ b/nbextensions/config/main.css
@@ -61,6 +61,35 @@
     content: "\f06a  (incompatible, enabled)";
 }
 
+/* styles for the readme */
+
+.nbext-readme > .nbext-readme-contents {
+    /* padding
+        top 0 to ensure box shadow of child is hidden (with overflow-y: hidden)
+        side & bottom sufficient to show box shadow of child */
+    padding: 0 12px 12px;
+    overflow-y: hidden;
+}
+
+.nbext-readme > h3 {
+    padding: 0 12px; /* to match nbext-readme-contents */
+}
+
+.nbext-readme > .nbext-readme-contents:not(:empty) {
+    margin-top: 0.5em;
+    border-top: 1px solid #ccc;
+}
+
+.nbext-readme > .nbext-readme-contents > .rendered_html {
+    padding: 0.5em 1em;
+    /* z-index & margin-top to clip box shadow behind parent */
+    margin-top: 0;
+    z-index: -10;
+    -webkit-box-shadow: 0 0 12px 1px rgba(87, 87, 87, 0.2);
+       -moz-box-shadow: 0 0 12px 1px rgba(87, 87, 87, 0.2);
+            box-shadow: 0 0 12px 1px rgba(87, 87, 87, 0.2);
+}
+
 /* styles for elements in an extension's UI */
 
 .nbext-activate-btns .btn {

--- a/nbextensions/config/main.js
+++ b/nbextensions/config/main.js
@@ -522,9 +522,12 @@ define([
                     var min_scrollTop = curr_scrollTop +
                                         ext_ui[0].getBoundingClientRect().top +
                                         - site[0].getBoundingClientRect().top +
-                                        - site.outerHeight()/4;
+                                        - site.outerHeight();
+                    // scroll to ensure at least title is visible
                     if (curr_scrollTop < min_scrollTop) {
-                        site.animate({scrollTop: min_scrollTop});
+                        site.animate({
+                            scrollTop: min_scrollTop + ext_ui.children('h3')[0].getBoundingClientRect().bottom - ext_ui[0].getBoundingClientRect().top
+                        });
                     }
                 }
             });

--- a/nbextensions/config/main.js
+++ b/nbextensions/config/main.js
@@ -361,19 +361,21 @@ define([
      */
     var load_readme = function (extension) {
         var readme_div = $('.nbext-readme .nbext-readme-contents').empty();
-        var readme_title = $('.nbext-readme h3').empty();
+        var readme_title = $('.nbext-readme > h3').empty();
         if (!extension.Link) return;
 
         var url = extension.Link;
         var is_absolute = /^(f|ht)tps?:\/\//i.test(url);
         if (is_absolute || utils.splitext(url)[1] !== '.md') {
-            if (! $('.nbext-readme-more-link')) {
+            var desc = $('#' + extension.id + ' .nbext-desc');
+            var link = desc.find('.nbext-readme-more-link');
+            if (link.length === 0) {
                 // provide a link only
-                $('<a/>')
+                link = $('<a/>')
                     .addClass('nbext-readme-more-link')
                     .text('more...')
                     .attr('href', url)
-                    .appendTo('#' + extension.id + ' .nbext-desc');
+                    .appendTo(desc);
             }
             return;
         }

--- a/nbextensions/config/render/render.js
+++ b/nbextensions/config/render/render.js
@@ -192,7 +192,7 @@ define([
                 page.show();
                 // See http://stackoverflow.com/questions/13735912
                 var el = $(window.location.hash);
-                if (el) el[0].scrollIntoView();
+                if (el.length > 0) el[0].scrollIntoView();
             }
         });
     };

--- a/nbextensions/config/render/rendermd.css
+++ b/nbextensions/config/render/rendermd.css
@@ -25,17 +25,17 @@
     border-radius: 2px;
 }
 
-#render-container pre {
+.rendered_html pre {
   background-color: #f5f5f5;
   padding: 4px;
 }
 
-#render-container code {
+.rendered_html code {
   background-color: #f9f2f4;
   padding: 2px 4px;
 }
 
-#render-container pre code {
+.rendered_html pre code {
   background-color: transparent;
   padding: 0;
 }

--- a/templates/nbextensions.html
+++ b/templates/nbextensions.html
@@ -21,11 +21,6 @@ data-extension-list='{{extension_list}}'
 		(<a href="{{base_url}}nbextensions/config/rendermd/nbextensions/config/readme.md">more information</a>)
 	</span>
 </div>
-<div class="nbext-showhide-incompat" style="display: none;">
-	disable settings for extensions without explicit compatibility
-	(they may break your notebook environment,
-	 but can be useful to show for extension development)
-</div>
 
 {% endblock %}
 
@@ -35,7 +30,15 @@ data-extension-list='{{extension_list}}'
 
 {% block site %}
 
-<div id="notebook-container" class="container"></div>
+<div id="notebook-container" class="container">
+	<div class="row nbext-row container-fluid nbext-selector">
+		<h4>Configurable extensions</h4>
+		<div class="nbext-showhide-incompat">
+			disable configuration for extensions without explicit compatibility
+			(they may break your notebook environment, but can be useful to show for extension development)
+		</div>
+	</div>
+</div>
 
 {% endblock %}
 

--- a/templates/nbextensions.html
+++ b/templates/nbextensions.html
@@ -38,6 +38,10 @@ data-extension-list='{{extension_list}}'
 			(they may break your notebook environment, but can be useful to show for extension development)
 		</div>
 	</div>
+	<div class="row nbext-readme">
+		<h3></h3>
+		<div class="nbext-readme-contents"></div>
+	</div>
 </div>
 
 {% endblock %}
@@ -47,6 +51,6 @@ data-extension-list='{{extension_list}}'
 	{{super()}}
 
 	<script type="text/javascript" charset="utf-8">
-		require(["nbextensions/config/main"]);		
+		require(["nbextensions/config/main"]);
 	</script>
 {% endblock %}

--- a/templates/nbextensions.html
+++ b/templates/nbextensions.html
@@ -16,7 +16,7 @@ data-extension-list='{{extension_list}}'
 {% block headercontainer %}
 
 <div class="pull-left nbext-page-title-wrap">
-	<span class="nbext-page-title" style="display: none;">
+	<span class="nbext-page-title">
 		Configuration for Notebook Extensions
 		(<a href="{{base_url}}nbextensions/config/rendermd/nbextensions/config/readme.md">more information</a>)
 	</span>

--- a/templates/nbextensions.html
+++ b/templates/nbextensions.html
@@ -41,7 +41,9 @@ data-extension-list='{{extension_list}}'
 
 {% block script %}
 
-    {{super()}}
+	{{super()}}
 
-<script src="{{base_url}}nbextensions/config/main.js" type="text/javascript" charset="utf-8"></script>
+	<script type="text/javascript" charset="utf-8">
+		require(["nbextensions/config/main"]);		
+	</script>
 {% endblock %}

--- a/templates/rendermd.html
+++ b/templates/rendermd.html
@@ -34,9 +34,12 @@ data-md-url='{{md_url}}'
 
 {% block script %}
 
-    {{super()}}
+	{{super()}}
 
-<script type="text/javascript" charset="utf-8">
-    require(["nbextensions/config/render/render"]);
-</script>
+	<script type="text/javascript" charset="utf-8">
+		require(["nbextensions/config/render/render"], function(rendermd_module) {
+			rendermd_module.render_markdown_page();
+		});
+	</script>
+	
 {% endblock %}


### PR DESCRIPTION
As first discussed in #379, This PR updates the config page to get extensions' markdown readme files to render on the config page directly, rather than on a separate page. This is accomplished by patching the marked.js renderer to create images and links with absolute URLs as their src/href attributes from relative URLs in the markdown (otherwise, the markdown URL is relative to the markdown file, but it's displayed on the config page, so the relative link points to the wrong place).

There are also a couple of bug fixes, and some attempts at UI improvements/fixes for annoyances.

