### PR TITLE
[Python-markdown] Fix error when the returned content includes newlines

### DIFF
--- a/nbextensions/usability/python-markdown/main.js
+++ b/nbextensions/usability/python-markdown/main.js
@@ -82,9 +82,10 @@ define([
                                     html = ul['text/html'];
                                 } else {
                                     html = marked(ul['text/plain']);
-                                    var t = html.match(/<p>(.*?)<\/p>/)[1]; //strip <p> and </p> that marked adds and we don't want
+                                    // [\s\S] is used to also catch newlines
+                                    var t = html.match(/<p>([\s\S]*?)<\/p>/)[1]; //strip <p> and </p> that marked adds and we don't want
                                     html = t ? t : html;
-                                    var q = html.match(/&#39;(.*?)&#39;/); // strip quotes from strings
+                                    var q = html.match(/&#39;([\s\S]*?)&#39;/); // strip quotes from strings
                                     if (q !== null) html = q[1]
                                 }
                             }


### PR DESCRIPTION
## How to reproduce:

In a Python cell:
```python
import numpy
```

And in the markdown cell:
```markdown
This will trigger an error: {{numpy.matrix([[0], [1]])}}
```
## Fix

In this case, python will return a string containing an unescaped newline
The current regex will not be able to match and the code is going to throw
In order to fix this bug, we simply replace the dot in the regex by [\s\S] that will also match new lines
