### PR TITLE
Possible workaround for  https://github.com/jupyter/notebook/issues/699

### DIFF
--- a/nbextensions/usability/toc/main.js
+++ b/nbextensions/usability/toc/main.js
@@ -10,6 +10,7 @@ define(["require", "jquery", "base/js/namespace"], function (require, $, IPython
     // last() is the |P anchor which lights up when you hoover over the headline
     hclone.children().last().remove();
     a.html(hclone.html());
+    a.on('click',function(){setTimeout($.ajax, 100) }) //workaround for  https://github.com/jupyter/notebook/issues/699 
     return a;
   };
 


### PR DESCRIPTION
This is a quick workaround for toc extension, since the https://github.com/jupyter/notebook/issues/699, "Auto-Scrolling/Jumping to Previous Location Link"  renders the toc extension quite unusable https://github.com/ipython-contrib/IPython-notebook-extensions/issues/424. The issue only affects Chrome/Chromium. The workaround consists in issuing a $.ajax(), which if I understand well, resets the queue of ajax requests. The suggestion comes from @jhamrick in the discussion referenced above. This is called, after a small delay, after each click on a link in the toc window.  It seems to work (at least for me); hope it will also for others.