### PR TITLE
Fix hierarchical_collapse for jupyter 4.x

### DIFF
--- a/nbextensions/testing/hierarchical_collapse/main.js
+++ b/nbextensions/testing/hierarchical_collapse/main.js
@@ -6,7 +6,8 @@ define([
     'base/js/events'
 ], function(IPython, $, require, events) {
       "use strict";
-      if (IPython.version[0] != 3) {
+
+      if (IPython.version[0] < 3) {
         console.log("This extension requires IPython 3.x");
         return;
       }

--- a/nbextensions/testing/hierarchical_collapse/main.js
+++ b/nbextensions/testing/hierarchical_collapse/main.js
@@ -654,10 +654,13 @@ define([
         console.log("hierarchical_collapse notebook extension loaded correctly");
 
         return true;
-      }
+      };
 
 
       // Initialize the extension
-      init_toggle_heading();
+      var extension = {
+          load_ipython_extension : init_toggle_heading
+      };
+      return extension;
 
     });


### PR DESCRIPTION
Hi folks

This fix allows extension hierarchical_collapse to load with jupyter 4.x. 
This required two simple changes:
* version-check only accepted version == 3, now fixed to accept any version >= 3
* adapted the loading to comply with `load_ipython_extension` requirements.

Thanks for reviewing and merging :) 