### PR TITLE
Pip install attempt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ coverage.xml
 docs/_build/
 
 .idea
+
+#pip install
+Python_contrib_nbextensions.egg-info/
+dist/

--- a/configure_nbextensions.py
+++ b/configure_nbextensions.py
@@ -34,7 +34,7 @@ def update_config(config_file):
     if debug is True:
         print("Configuring %s" % config_file)
 
-    new_config = "import os\nimport sys\nsys.path.append(os.path.join('%s', 'extensions'))" % data_dir
+    new_config = "import os\nimport sys\nsys.path.append(os.path.join(r'%s', 'extensions'))" % data_dir
 
     # add config
     f = open(config_file, 'a+')

--- a/configure_nbextensions.py
+++ b/configure_nbextensions.py
@@ -1,0 +1,143 @@
+# -*- coding: utf-8 -*-
+# Install notebook extensions
+
+from jupyter_core.paths import jupyter_config_dir, jupyter_data_dir
+from traitlets.config.loader import Config, JSONFileConfigLoader
+import os
+import sys
+import json
+import psutil
+
+marker = '#--- nbextensions configuration ---'
+debug = False
+
+def remove_old_config(configdata):
+    """ Remove old configuration entries
+
+    :param configdata: python configuration data
+    """
+    marker_found = []
+    lines = configdata.splitlines()
+    for i, l in enumerate(lines):
+        if l.find(marker) >= 0:
+            marker_found.append(i)
+    start = marker_found[0]
+    end = marker_found[-1]
+    return '\n'.join(lines[0:start] + lines[end+1:])
+
+
+def update_config(config_file):
+    """ Update .py configuration file with new path to extensions
+
+    :param config_file: name of the config file to be updated
+    """
+    if debug is True:
+        print("Configuring %s" % config_file)
+
+    new_config = "import os\nimport sys\nsys.path.append(os.path.join('%s', 'extensions'))" % data_dir
+
+    # add config
+    f = open(config_file, 'a+')
+    pyconfig = f.read()
+    f.close()
+
+    if pyconfig.find(marker) >= 0:
+        pyconfig = remove_old_config(pyconfig)
+
+    pyconfig = marker + '\n' + new_config + '\n' + marker + '\n' + pyconfig
+
+    # write config file
+    f = open(config_file, 'w')
+    f.write(pyconfig)
+    f.close()
+
+
+for p in psutil.process_iter():
+    if ("python" or "jupyter") in p.name():
+        c = p.cmdline()
+        if len(c) == 2 and "jupyter-notebook" in c[1]:
+            print("Cannot configure while the Jupyter notebook server is running")
+            exit(1)
+
+if len(sys.argv) == 2 and sys.argv[1] == "debug":
+    debug = True
+
+print("Configuring the Jupyter notebook extensions.")
+
+# Get the local configuration file path
+# Use $PREFIX for Anaconda
+data_dir = os.getenv('PREFIX', None)
+if data_dir is None:
+    data_dir = jupyter_data_dir()
+else:
+    data_dir = os.path.join(data_dir, 'share/jupyter')
+
+if debug is True:
+    print("Extensions and templates path: %s" % data_dir)
+
+config_dir = jupyter_config_dir()
+print("Configuration files directory: %s" % config_dir)
+if os.path.exists(config_dir) is False:
+    os.mkdir(config_dir)
+    if debug is True:
+        print("Creating directory %s" % config_dir)
+
+
+
+def load_json_config(json_filename):
+    """ Load config as JSON file
+    :param json_filename: Filename of JSON file
+    :return: Traitlets based configuration
+    """
+    json_config = os.path.join(jupyter_config_dir(), json_filename)
+    if debug is True: print("Configuring %s" % json_config)
+    if os.path.isfile(json_config) is True:
+        cl = JSONFileConfigLoader(json_config)
+        config = cl.load_config()
+    else:
+        config = Config()
+    return config
+
+
+def save_json_config(json_file, newconfig):
+    """ Save config as JSON file
+    :param json_file: Filename of JSON file
+    :param newconfig: New traitlets based configuration
+    """
+    s = json.dumps(newconfig, indent=2, separators=(',', ': '), sort_keys=True)
+    json_config = os.path.join(jupyter_config_dir(), json_file)
+    with open(json_config, 'w') as f:
+        f.write(s)
+
+# Update nbconvert JSON configuration
+json_file = 'jupyter_nbconvert_config.json'
+config = load_json_config(json_file)
+
+# Set template path, pre- and postprocessors of notebook extensions
+newconfig = Config()
+newconfig.Exporter.template_path = ['.', os.path.join(data_dir, 'templates')]
+newconfig.Exporter.preprocessors = ["pre_codefolding.CodeFoldingPreprocessor", "pre_pymarkdown.PyMarkdownPreprocessor"]
+newconfig.NbConvertApp.postprocessor_class = 'post_embedhtml.EmbedPostProcessor'
+config.merge(newconfig)
+config.version = 1
+save_json_config(json_file, config)
+
+# Update nbconvert PY configuration
+py_config = os.path.join(jupyter_config_dir(), 'jupyter_nbconvert_config.py')
+update_config(py_config)
+
+# Update notebook JSON configuration
+json_file = 'jupyter_notebook_config.json'
+config = load_json_config(json_file)
+
+# Add server extension of /nbextension/ configuration tool and template path
+newconfig = Config()
+newconfig.NotebookApp.server_extensions = ["nbextensions"]
+newconfig.NotebookApp.extra_template_paths = [os.path.join(jupyter_data_dir(),'templates') ]
+config.merge(newconfig)
+config.version = 1
+save_json_config(json_file, config)
+
+# Update notebook PY configuration
+py_config = os.path.join(jupyter_config_dir(), 'jupyter_notebook_config.py')
+update_config(py_config)

--- a/install.py
+++ b/install.py
@@ -1,0 +1,83 @@
+# Install notebook extensions
+
+from jupyter_core.paths import jupyter_data_dir
+import os
+import sys
+import shutil
+import IPython
+import notebook
+
+debug = False
+
+if IPython.__version__[0] < '4':
+    print("IPython version 4.x is required")
+    exit(1)
+
+if notebook.__version__[0] < '4':
+    print("notebook version 4.x is required")
+    exit(1)
+
+if len(sys.argv) == 2 and sys.argv[1] == "debug":
+    debug = True
+
+print("Installing Jupyter notebook extensions.")
+
+# http://stackoverflow.com/questions/12683834/how-to-copy-directory-recursively-in-python-and-overwrite-all
+def recursive_overwrite(src, dest, ignore=None):
+    if os.path.isdir(src):
+        if not os.path.isdir(dest):
+            os.makedirs(dest)
+        files = os.listdir(src)
+        if ignore is not None:
+            ignored = ignore(src, files)
+        else:
+            ignored = set()
+        for f in files:
+            if f not in ignored:
+                recursive_overwrite(os.path.join(src, f), 
+                                    os.path.join(dest, f), 
+                                    ignore)
+    else:
+        shutil.copyfile(src, dest)
+
+#
+# 1. Get the local configuration file path
+#
+data_dir = os.getenv('PREFIX', None)
+if data_dir == None:
+    data_dir = jupyter_data_dir()
+else:
+    data_dir = os.path.join(data_dir, 'share/jupyter')
+
+print("Extensions and templates path: %s" % data_dir)
+
+if os.path.exists(data_dir) is False:
+    os.mkdir(data_dir)
+    if debug is True: print("Creating directory %s" % data_dir)
+
+#
+# 2. Install files
+#   Indiscriminately copy all files from the nbextensions, extensions and template directories
+#   Currently there is no other way, because there is no definition of a notebook extension package
+#
+        
+# copy extensions to IPython extensions directory
+src = 'extensions'
+destination = os.path.join(data_dir, 'extensions')
+if debug is True: print("Install Python extensions to %s" % destination)
+recursive_overwrite(src, destination)
+
+# Install templates
+src = 'templates'
+destination = os.path.join(data_dir, 'templates')
+if debug is True: print("Install templates to %s" % destination)
+recursive_overwrite(src, destination)
+
+# Install nbextensions
+src = 'nbextensions'
+destination = os.path.join(data_dir, 'nbextensions')
+if debug is True: print("Install notebook extensions to %s" % destination)
+recursive_overwrite(src, destination)
+
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,12 @@
+ipython >=4
+jupyter_client
+jupyter_core
+notebook
+nbconvert
+nbformat
+python
+traitlets
+psutil
+traitlets
+pyaml
+

--- a/setup.py
+++ b/setup.py
@@ -1,188 +1,90 @@
-# Install notebook extensions
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 
-from jupyter_core.paths import jupyter_config_dir, jupyter_data_dir
-from traitlets.config.loader import Config, JSONFileConfigLoader
-import os
-import sys
-import json
-import shutil
-import psutil
-import IPython
-import notebook
-
-marker = '#--- nbextensions configuration ---'
+#pip install https://github.com/jfbercher/IPython-notebook-extensions/archive/master.zip --user
+#pip install git+https://github.com/jfbercher/IPython-notebook-extensions@master#egg=IPython-contrib-nbextensions --user
 
 
-if IPython.__version__[0] < '4':
-    print("IPython version 4.x is required")
-    exit()
+"""
+*********************************************************************************************************
+IPython-contrib-nbextensions - (C) 2013-2015, IPython-contrib Developers - All rights reserved.
 
-if notebook.__version__[0] < '4':
-    print("notebook version 4.x is required")
+contains a collection of extensions that add functionality to the Jupyter notebook. These extensions are 
+mostly written in Javascript and will be loaded locally in your Browser. 
 
-for p in psutil.process_iter():
-    if "jupyter-notebook" in p.name():
-        print("Cannot install while the Jupyter notebook server is running")
-        exit()
+The IPython-contrib repository https://github.com/ipython-contrib/IPython-notebook-extensions 
+is maintained independently by a group of users and developers and not officially related to the 
+IPython development team.
 
-if len(sys.argv) == 2 and sys.argv[1] == "install":
-    print("Installing Jupyter notebook extensions")
-else:
-    print("To install the notebook extensions use 'python setup.py install'")
-    exit()
+The maturity of the provided extensions may vary, please create an issue if you encounter any problems.
 
-
-# http://stackoverflow.com/questions/12683834/how-to-copy-directory-recursively-in-python-and-overwrite-all
-def recursive_overwrite(src, dest, ignore=None):
-    if os.path.isdir(src):
-        if not os.path.isdir(dest):
-            os.makedirs(dest)
-        files = os.listdir(src)
-        if ignore is not None:
-            ignored = ignore(src, files)
-        else:
-            ignored = set()
-        for f in files:
-            if f not in ignored:
-                recursive_overwrite(os.path.join(src, f), 
-                                    os.path.join(dest, f), 
-                                    ignore)
-    else:
-        shutil.copyfile(src, dest)
+Released under Modified BSD License, read COPYING file for more details.
+*********************************************************************************************************
+"""
 
 
-def remove_old_config(config):
-    """ Remove old configuration entries 
-    
-    :param config: python configuration data
-    """
-    marker_found = []
-    lines = config.splitlines()
-    for i, l in enumerate(lines):
-        if l.find(marker) >= 0:
-            marker_found.append(i)
-    start = marker_found[0]
-    end = marker_found[-1]
-    return '\n'.join(lines[0:start] + lines[end+1:])
+#from distutils.core import setup
+from setuptools import setup, find_packages
+from os.path import join
+from sys import exit, prefix, version_info, argv
+
+#import os, fnmatch
+#FILES = [os.path.join(dirpath, f)
+#    for dirpath, dirnames, files in os.walk('.')
+#    for f in fnmatch.filter(files, '*') if '.git' not in dirpath]
 
 
-def update_config(config_file, newconfig_file):
-    """ Update .py configuration file with new path to extensions 
-    
-    :param config_file: name of the existing python config file
-    :param newconfig_file: name of the config file to be written into the existing python config file
-    """
-    if os.path.isfile(config_file) is True:
-        f = open(config_file, 'r')
-        config = f.read()
-        f.close()
-    else:
-        config = ''
-    
-    # add config
-    f = open(newconfig_file, 'r')
-    new_config = f.read()
-    f.close()
-    
-    if config.find(marker) >= 0:
-        config = remove_old_config(config)
 
-    config = marker + '\n' + new_config + '\n' + marker + '\n' + config    
-    
-    # write config file
-    f = open(config_file, 'w')
-    f.write(config)
-    f.close()        
-
+if 'bdist_wheel' in argv:
+    raise RuntimeError("This setup.py does not support wheels")
 
 #
-# 1. Get the local configuration file path
-#
-config_dir = jupyter_config_dir()
-data_dir = jupyter_data_dir()
-
-print("Configuration files directory: %s" % config_dir)
-print("Extensions and templates path: %s" % data_dir)
-
-# now test if path exists
-if os.path.exists(config_dir) is False:
-    os.mkdir(config_dir)
-if os.path.exists(data_dir) is False:
-    os.mkdir(data_dir)
+if 'install' in argv: #-----------------------------------
+    print("Running source install...")
+    import install
+    print('Done!')
+    print("Configuring extensions...")
+    import configure_nbextensions
+    print('Done!')
 
 #
-# 2. Install files
-#   Indiscriminately copy all files from the nbextensions, extensions and template directories
-#   Currently there is no other way, because there is no definition of a notebook extension package
-#
-        
-# copy extensions to IPython extensions directory
-src = 'extensions'
-destination = os.path.join(data_dir, 'extensions')
-print("Install Python extensions to %s" % destination)
-recursive_overwrite(src, destination)
 
-# Install templates
-src = 'templates'
-destination = os.path.join(data_dir, 'templates')
-print("Install templates to %s" % destination)
-recursive_overwrite(src, destination)
+# pip/setuptools install ------------------------------
 
-# Install nbextensions
-src = 'nbextensions'
-destination = os.path.join(data_dir, 'nbextensions')
-print("Install notebook extensions to %s" % destination)
-recursive_overwrite(src, destination)
+classifiers = """\
+Development Status :: 1 - Planning
+Intended Audience :: End Users/Desktop
+Intended Audience :: Science/Research
+License :: OSI Approved :: BSD License
+Natural Language :: English
+Operating System :: OS Independent
+Programming Language :: JavaScript
+Programming Language :: Python :: 3
+Topic :: Utilities
+"""
+
+print(__doc__)
+
+# check python version
+ver = (version_info.major, version_info.minor)
+if ver < (3, 0):
+    print('ERROR: Python 3.x or higher is required.')
+    exit(-1)
 
 
-#
-# 3. Update nbconvert configuration
-#
-json_config = os.path.join(jupyter_config_dir(), 'jupyter_nbconvert_config.json')
-print("Configuring %s" % json_config)
-if os.path.isfile(json_config) is True:
-    cl = JSONFileConfigLoader(json_config)
-    config = cl.load_config()
-else:
-    config = Config()
-newconfig = Config()
-# Set template path, pre- and postprocessors of notebook extensions
-newconfig.Exporter.template_path = [os.path.join(data_dir, 'templates')]
-newconfig.Exporter.preprocessors = ["pre_codefolding.CodeFoldingPreprocessor", "pre_pymarkdown.PyMarkdownPreprocessor"]
-newconfig.NbConvertApp.postprocessor_class = 'post_embedhtml.EmbedPostProcessor'
-config.merge(newconfig)
-config.version = 1
-s=json.dumps(config, indent=2, separators=(',', ': '), sort_keys=True)
-with open(json_config, 'w') as f:
-    f.write(s)
 
-py_config = os.path.join(jupyter_config_dir(), 'jupyter_nbconvert_config.py')
-print("Configuring %s" % py_config)
-
-new_py_config = 'jupyter_nbconvert_config.py'
-update_config(py_config, new_py_config)
-
-#
-# 4. Update notebook configuration
-#
-fname = os.path.join(config_dir, 'jupyter_notebook_config.json')
-print("Configuring %s" % fname)
-if os.path.isfile(json_config) is True:
-    cl = JSONFileConfigLoader(json_config)
-    config = cl.load_config()
-else:
-    config = Config()
-newconfig = Config()
-# Add server extension of /nbextension/ configuration tool
-newconfig.NotebookApp.server_extensions = ["nbextensions"]
-config.merge(newconfig)
-config.version = 1
-s = json.dumps(config, indent=2, separators=(',', ': '), sort_keys=True)
-with open(fname, 'w') as f:
-    f.write(s)
-
-    py_config = os.path.join(jupyter_config_dir(), 'jupyter_notebook_config.py')
-print("Configuring %s" % py_config)
-
-new_py_config = 'jupyter_notebook_config.py'
-update_config(py_config, new_py_config)
+setup(name='Python-contrib-nbextensions',
+      version='master',
+      description=__doc__.split("\n")[2],
+      long_description='\n'.join(__doc__.split("\n")[2:]).strip(),
+      author='IPython-contrib Developers',
+      author_email='@gmail.com',
+      url='https://github.com/ipython-contrib/IPython-notebook-extensions',
+      platforms='POSIX',
+      keywords=['IPython Jupyter notebook extension'],
+      classifiers=filter(None, classifiers.split("\n")),
+      license='BSD',
+      install_requires = ['ipython >=4','jupyter','psutil','pyaml'],
+      #packages=['IPython-contrib-nbextensions'],
+      # **addargs
+)


### PR DESCRIPTION
This is an attempt to get a kind of pip installable version of the repo, *directly from the repo*, as suggested many times eg #393. It is no more necessary to clone the repo since pip will do the download of the last version of the master branch for the user. Also pip automatically launches the install. 

- Please note that this may not be a "good practice" since the repo is actually not a python package, and cannot be uninstalled via pip, but only manually for now. 

This builds on the new conda installation recipe #417 and simply adds a setup.py that checks for the dependencies and then calls both install.py and configure_nbextensions (@juhasch, please note that I had to rename configure-nbextensions into configure_nbextensions because python's import do not like dashes in filenames). 

**Usage**: if the PR is accepted, installation will be possible via
`pip install  https://github.com/ipython-contrib/IPython-notebook-extensions/archive/master.zip --user`
verbose mode can be enabled with -v switch eg `pip -v install ...` , and upgrade with a --upgrade. A system install can be done by omitting the --user switch.  
If it it works, we will need to update the documentation. 

**Testing**: For now, install can be tested from my personal repo
`pip install  https://github.com/jfbercher/IPython-notebook-extensions/archive/pip-install.zip --user`

After a first install, the distribution can be updated either 
- by adding --upgrade at the end of the command-line
- by first "uninstalling" via `pip uninstall Python-contrib-nbextensions` (this is not a true uninstall but simply an erase of the install reference in the pip manager)

This PR was tested on debian 9, with a vanilla Python/Jupyter install, and under windows 8.1 + anaconda 2.3 distrib. 
Hope it will work for others and will be useful!
 
