### PR TITLE
in `nbextensions/usability/hide_input`:

### DIFF
--- a/nbextensions/usability/hide_input/hide-input.yaml
+++ b/nbextensions/usability/hide_input/hide-input.yaml
@@ -2,4 +2,5 @@ Type: IPython Notebook Extension
 Compatibility: 3.x 4.x
 Main: main.js
 Name: Hide input
+Icon: icon.png
 Description: "toggle display of selected code cell's input"


### PR DESCRIPTION
 * edit yaml descriptor to use the currently un-used icon