### PR TITLE
in `nbextensions/usability/code_font_size`:

### DIFF
--- a/nbextensions/usability/code_font_size/code_font_size.js
+++ b/nbextensions/usability/code_font_size/code_font_size.js
@@ -29,7 +29,7 @@ define([
                     pre_style = pre_css.cssRules[0];
                 }
 
-                var font_size = pre_style.fontSize;
+                var font_size = pre_style.fontSize || "";
                 if(font_size == "")
                     font_size = 14;
                 else


### PR DESCRIPTION
 * fix default handling of `pre_style.fontSize`, which broke if it was undefined, rather than defaulting to 14 as it ought to.