### PR TITLE
bugfix for (bugfix for twitter bootstrap css in config/main)

### DIFF
--- a/nbextensions/config/main.css
+++ b/nbextensions/config/main.css
@@ -61,15 +61,10 @@
     content: "\f06a  (incompatible, enabled)";
 }
 
-/* bugfix for using .container with padding: we need at the padding extra  to width. Below that, we */ 
-@media (min-width: 768px) {
+/* bugfix for using .container with padding: we need 15px extra to width. */ 
+@media (min-width: 768px) and (max-width: 783px) {
     .container {
         width: auto;
-    }
-}
-@media (min-width: 783px) {
-    .container {
-        width: 768px;
     }
 }
 /* styles for the readme */


### PR DESCRIPTION
Apologies, I should have tested 89ff1f316cd9ecf4520b8b7e59c24eae98bcb27e better to begin with.
I inadvertantly limited the config page to have a maximum width of 768px.

This shoul fix the css fix from 89ff1f316cd9ecf4520b8b7e59c24eae98bcb27e so that widths aren't overridden for larger screen sizes