### PR TITLE
in `nbextensions/usability/keyboard_shortcut_editor`:

### DIFF
--- a/nbextensions/usability/keyboard_shortcut_editor/keyboard_shortcut_editor.yaml
+++ b/nbextensions/usability/keyboard_shortcut_editor/keyboard_shortcut_editor.yaml
@@ -5,3 +5,8 @@ Main: main.js
 Icon: icon.png
 Link: README.md
 Description: Edit or remove Jupyter keyboard shortcuts, or add you own new ones
+Parameters:
+- name: kse_show_rebinds
+  description: "Show shortcut editing controls in the shortcuts dialog. If this is false, shortcuts can't be edited directly from the notebook, but any existing edits are still applied. Useful essentially just to make the shortcuts dialog a bit cleaner"
+  input_type: checkbox
+  default: true

--- a/nbextensions/usability/keyboard_shortcut_editor/main.js
+++ b/nbextensions/usability/keyboard_shortcut_editor/main.js
@@ -33,6 +33,7 @@ define([
 
 	// define default values for config parameters
 	var params = {
+		'kse_show_rebinds': true,
 		// mode, action name, new combo
 		'kse_rebinds': {
 			// command-mode rebindings
@@ -213,9 +214,7 @@ define([
 		update_params();
 		apply_config_rebinds();
 		var title = $('#keyboard_shortcuts').attr('title');
-		title += ' & controls to edit them';
-		$('#keyboard_shortcuts').attr('title',  title);
-		Jupyter.quick_help.show_keyboard_shortcuts();
+		$('#keyboard_shortcuts').attr('title',  title + ' & controls to edit them');
 	});
 
 	function reverse_spec (spec) {
@@ -681,6 +680,10 @@ define([
 	}
 
 	function quickhelp_div_add_rebind_controls (div, mode) {
+		if (!params.kse_show_rebinds) {
+			return div;
+		}
+
 		div
 			.data('kse_mode', mode)
 			.addClass('kse-div');


### PR DESCRIPTION
 * remove code which made the keyboard shortcuts dialog open on notebook load (it was left in from testing)
 * add an option to not show the edit controls, while keeping the edits already configured, for brevity of the dialog