### PR TITLE
Fixed install crash if config files don't exist

### DIFF
--- a/configure_nbextensions.py
+++ b/configure_nbextensions.py
@@ -29,7 +29,8 @@ def remove_old_config(configdata):
 def make_backup(filename):
     import shutil
     backup = filename + ".bak"
-    shutil.copy(filename,backup)
+    if os.path.exists(filename):
+        shutil.copy(filename,backup)
 
 
 def update_config(config_file):


### PR DESCRIPTION
If any of the following files don't exit (fresh install)

    ~/.jupyter/jupyter_nbconvert_config.json
    ~/.jupyter/jupyter_nbconvert_config.py
    ~/.jupyter/jupyter_notebook_config.json
    ~/.jupyter/jupyter_notebook_config.py

Then `pip install https://github.com/ipython-contrib/IPython-notebook-extensions/archive/master.zip --user` will crash when it goes to make the backup. This should still allow for the backups, but skip them the first time