### PR TITLE
Added multiple ruler support to the ruler extension

### DIFF
--- a/nbextensions/usability/ruler/main.js
+++ b/nbextensions/usability/ruler/main.js
@@ -26,8 +26,6 @@ define([
     };
 
     config.loaded.then(function() {
-console.log(config.data.ruler_color)
-console.log(config.data.ruler_color.length)
         if (config.data.hasOwnProperty('ruler_color') && config.data.ruler_color.length>0) {
             ruler_color = config.data.ruler_color;
         }
@@ -58,7 +56,7 @@ console.log(config.data.ruler_color.length)
                 lineStyle: ruler_linestyle[i % ruler_linestyle.length]
             });
         }
-console.log(rulers[0])
+
         var cells = IPython.notebook.get_cells();
         for(var i in cells) {
             var cell = cells[i];

--- a/nbextensions/usability/ruler/main.js
+++ b/nbextensions/usability/ruler/main.js
@@ -13,9 +13,9 @@ define([
 ], function(IPython, $, require, events, configmod, utils, codemirror) {
     "use strict";
 
-    var ruler_column = 78;
-    var ruler_color = "#ff0000";
-    var ruler_linestyle = "dashed";
+    var ruler_column = [78];
+    var ruler_color = ["#ff0000"];
+    var ruler_linestyle = ["dashed"];
 
     var base_url = utils.get_body_data("baseUrl");
     var config = new configmod.ConfigSection('notebook', {base_url: base_url});
@@ -26,28 +26,37 @@ define([
     };
 
     config.loaded.then(function() {
-        if (config.data.hasOwnProperty('ruler_color')) {
+        if (config.data.hasOwnProperty('ruler_color') && config.data.ruler_color.length>1) {
             ruler_color = config.data.ruler_color;
         }
         console.log("ruler_color:", ruler_color);
 
         if (config.data.hasOwnProperty('ruler_column')) {
-            if (isNumber(config.data.ruler_column)) {
-                ruler_column = config.data.ruler_column;
+            var new_columns = []
+            for(var i in config.data.ruler_column) {
+                if (isNumber(config.data.ruler_column[i])) {
+                    new_columns.push(config.data.ruler_column[i]);
+                }
+            }
+            if (new_columns.length>0) {
+                ruler_column = new_columns
             }
         }
         console.log("ruler_column:", ruler_column);
 
-        if (config.data.hasOwnProperty('ruler_linestyle')) {
+        if (config.data.hasOwnProperty('ruler_linestyle') && config.data.ruler_linestyle.length>1) {
             ruler_linestyle = config.data.ruler_linestyle;
         }
         console.log("ruler_linestyle:", ruler_linestyle);
 
-        rulers.push({
-            color: ruler_color,
-            column: ruler_column,
-            lineStyle: ruler_linestyle
-        });
+        for(var i in ruler_column) {
+            rulers.push({
+                color: ruler_color[i % ruler_color.length],
+                column: ruler_column[i],
+                lineStyle: ruler_linestyle[i % ruler_linestyle.length]
+            });
+        }
+console.log(rulers[0])
         var cells = IPython.notebook.get_cells();
         for(var i in cells) {
             var cell = cells[i];

--- a/nbextensions/usability/ruler/main.js
+++ b/nbextensions/usability/ruler/main.js
@@ -26,7 +26,9 @@ define([
     };
 
     config.loaded.then(function() {
-        if (config.data.hasOwnProperty('ruler_color') && config.data.ruler_color.length>1) {
+console.log(config.data.ruler_color)
+console.log(config.data.ruler_color.length)
+        if (config.data.hasOwnProperty('ruler_color') && config.data.ruler_color.length>0) {
             ruler_color = config.data.ruler_color;
         }
         console.log("ruler_color:", ruler_color);
@@ -44,7 +46,7 @@ define([
         }
         console.log("ruler_column:", ruler_column);
 
-        if (config.data.hasOwnProperty('ruler_linestyle') && config.data.ruler_linestyle.length>1) {
+        if (config.data.hasOwnProperty('ruler_linestyle') && config.data.ruler_linestyle.length>0) {
             ruler_linestyle = config.data.ruler_linestyle;
         }
         console.log("ruler_linestyle:", ruler_linestyle);

--- a/nbextensions/usability/ruler/readme.md
+++ b/nbextensions/usability/ruler/readme.md
@@ -10,5 +10,5 @@ You can set the number of characters in the notebook extensions configration pag
 from IPython.html.services.config import ConfigManager
 ip = get_ipython()
 cm = ConfigManager(parent=ip)
-cm.update('notebook', {"ruler_column": 80})
+cm.update('notebook', {"ruler_column": [80]})
 ```

--- a/nbextensions/usability/ruler/readme.md
+++ b/nbextensions/usability/ruler/readme.md
@@ -12,3 +12,29 @@ ip = get_ipython()
 cm = ConfigManager(parent=ip)
 cm.update('notebook', {"ruler_column": [80]})
 ```
+
+#### Multiple Rulers ####
+To specify multiple rulers, set the `ruler_column` to an list of values, for example
+
+```Python
+cm.update('notebook', {"ruler_column": [10, 20, 30, 40, 50, 60, 70, 80]})
+```
+
+A separate color and style can be specified for each ruler.
+
+```Python
+cm.update('notebook', {"color": ["#000000", "#111111", "#222222", "#333333", "#444444",
+                                 "#555555", "#666666", "#777777", "#888888", "#999999"]})
+```
+
+Creating a repeating pattern for either color or style is as simple as giving a list shorter than the total number of rulers
+
+```Python
+cm.update('notebook', {"ruler_column": [10, 20, 30, 40, 50, 60, 70, 80]})
+cm.update('notebook', {"color": ["#FF0000", "#00FF00", "#0000FF"]})
+cm.update('notebook', {"style": ["dashed", "dotted"]})
+```
+
+will result in `red, green, blue, red, green, blue, red, green, blue, red` and alternating `dashed, dotted`
+
+See [here](http://www.w3schools.com/cssref/pr_border-left_style.asp) for other line styles

--- a/nbextensions/usability/ruler/ruler.yaml
+++ b/nbextensions/usability/ruler/ruler.yaml
@@ -7,13 +7,18 @@ Main: main.js
 Compatibility: 4.x
 Parameters:
 - name: ruler_column
-  input_type: number
+  input_type: list
+  list_element:
+    input_type: number
   description: Column where ruler is displayed
-  default: 78
+  default: [78]
 - name: ruler_color
-  input_type: color
+  input_type: list
+  list_element:
+    input_type: color
   description: Ruler color
-  default: "#ff0000"
+  default: ["#ff0000"]
 - name: ruler_linestyle
   description: 'Ruler style, e.g. solid, dashed'
-  default: dashed
+  input_type: list
+  default: ['dashed']


### PR DESCRIPTION
I tried to add multiple ruler support. All the fields are now arrays, with the same default values as before.

Since this NOW adds the possibility of `what if I add add multiple columns but only one or two colors`, I used `%` [here](https://github.com/andyneff/IPython-notebook-extensions/blob/multiple_rulers/nbextensions/usability/ruler/main.js#L54-L56) as more of a CYA than a feature, but it does make creating alternating color/style easier... 