### PR TITLE
pyaml --> pyyaml in setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ nbformat
 python
 traitlets
 psutil >=2.2.1
-pyaml
+pyyaml
 

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-#Usage: 
+#Usage:
 #pip install https://github.com/ipython-contrib/IPython-notebook-extensions/archive/master.zip --user
-#verbose mode can be enabled with -v switch eg pip -v install ...  
-#upgrade with a --upgrade. 
+#verbose mode can be enabled with -v switch eg pip -v install ...
+#upgrade with a --upgrade.
 #A system install can be done by omitting the --user switch.
 
 #Testing: pip install https://github.com/jfbercher/IPython-notebook-extensions/archive/pip-install.zip --user
@@ -14,11 +14,11 @@
 *********************************************************************************************************
 IPython-contrib-nbextensions - (C) 2013-2016, IPython-contrib Developers - All rights reserved.
 
-contains a collection of extensions that add functionality to the Jupyter notebook. These extensions are 
-mostly written in Javascript and will be loaded locally in your Browser. 
+contains a collection of extensions that add functionality to the Jupyter notebook. These extensions are
+mostly written in Javascript and will be loaded locally in your Browser.
 
-The IPython-contrib repository https://github.com/ipython-contrib/IPython-notebook-extensions 
-is maintained independently by a group of users and developers and not officially related to the 
+The IPython-contrib repository https://github.com/ipython-contrib/IPython-notebook-extensions
+is maintained independently by a group of users and developers and not officially related to the
 IPython development team.
 
 The maturity of the provided extensions may vary, please create an issue if you encounter any problems.
@@ -89,7 +89,7 @@ setup(name='Python-contrib-nbextensions',
       keywords=['IPython Jupyter notebook extension'],
       classifiers=filter(None, classifiers.split("\n")),
       license='BSD',
-      install_requires = ['ipython >=4','jupyter','psutil >=2.2.1','pyaml'],
+      install_requires = ['ipython >=4','jupyter','psutil >=2.2.1','pyyaml'],
       #packages=['IPython-contrib-nbextensions'],
       # **addargs
 )


### PR DESCRIPTION
in the requirements `pyaml` made installation fail, I suppose it must read `pyyaml`. At least with this modification everything install fine with `conda build`.

Build still ends with an error, but running `/bin/bash -x -e ~/anaconda/conda-bld/work/conda_build.sh` did make it work (somehow the `pyaml` is still coded somewhere)

Addresses issue #468