### PR TITLE
nbextensions/usability/toc2/: Fixed problems with skipped heading levels,  nested TOC lists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+*~
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/nbextensions/usability/toc2/main.css
+++ b/nbextensions/usability/toc2/main.css
@@ -2,7 +2,7 @@
 
 #toc {
   overflow-y: auto;
-  max-height: 300px;
+  max-height: 500px;
   padding: 0px;
 }
 
@@ -16,6 +16,12 @@
     display: block;
   }
 
+#toc ul.toc-item {
+    list-style-type: none;
+    padding: 0;
+    margin:  0;
+}
+
 #toc  ol.toc-item li:before {
     font-size: 90%;
     font-family: Georgia, Times New Roman, Times, serif;
@@ -27,7 +33,7 @@
 #toc-wrapper {
   position: fixed;
   top: 120px;
-  max-width:300px;
+  max-width:600px;
   right: 20px;
   border: thin solid rgba(0, 0, 0, 0.38);
   border-radius: 5px;
@@ -78,6 +84,12 @@
     font-style: normal;
 }
 
+#toc-wrapper .toc-item-num {
+    font-style: normal;
+    font-family: Georgia, Times New Roman, Times, serif;
+    color: black;
+}
+
 .lev1 {margin-left: 80px}
 .lev2 {margin-left: 100px}
 .lev3 {margin-left: 120px}
@@ -86,3 +98,4 @@
 .lev6 {margin-left: 180px}
 .lev7 {margin-left: 200px}
 .lev8 {margin-left: 220px}
+

--- a/nbextensions/usability/toc2/main.js
+++ b/nbextensions/usability/toc2/main.js
@@ -10,7 +10,7 @@ define(["require", "jquery", "base/js/namespace",  'services/config',
 
 // ...........Parameters configuration......................
  // define default values for config parameters if they were not present in general settings (notebook.json)
-    var cfg={'toc_threshold':4, 
+    var cfg={'toc_threshold':6, 
              'toc_number_sections':true, 
              'toc_cell':false,
              'toc_window_display':false}
@@ -18,9 +18,8 @@ define(["require", "jquery", "base/js/namespace",  'services/config',
     var toc_cell=cfg['toc_cell'];
     var number_sections = cfg['toc_number_sections'];
 
-
-   function read_config() {  // read after nb is loaded
-     // create config object to load parameters
+  function read_config() {  // read after nb is loaded
+    // create config object to load parameters
     var base_url = utils.get_body_data("baseUrl");
     var config = new configmod.ConfigSection('notebook', {base_url: base_url});
 
@@ -42,16 +41,15 @@ define(["require", "jquery", "base/js/namespace",  'services/config',
     // config may be specified at system level or at document level.
     if (IPython.notebook.metadata.toc !== undefined){ //configuration saved in nb
         console.log("config stored in nb")
-	cfg = IPython.notebook.metadata.toc;
+        cfg = IPython.notebook.metadata.toc;
         threshold = cfg['toc_threshold'];
         toc_cell=cfg['toc_cell'];
         number_sections = cfg['toc_number_sections'];
-	}
-    else {
+    } else {
         console.log("config stored in system")
-	config.load();
+        config.load();
         config.loaded.then(function() {update_params() })
-    } 
+    }
     config_loaded = true;
 }
 //.....................global variables....
@@ -60,13 +58,20 @@ define(["require", "jquery", "base/js/namespace",  'services/config',
     var config_loaded = false;
     var extension_initialized=false;
 
-//......... utilitary functions............    
+//......... utilitary functions............
 
-  var make_link = function (h) {
+  function incr_lbl(ary, h_idx){//increment heading label  w/ h_idx (zero based)
+      ary[h_idx]++;
+      for(var j= h_idx+1; j < ary.length; j++){ ary[j]= 0; }
+      return ary.slice(0, h_idx+1);
+  }
+
+  var make_link = function (h, num_lbl) {
     var a = $("<a/>");
     a.attr("href", '#' + h.attr('id'));
     // get the text *excluding* the link text, whatever it may be
     var hclone = h.clone();
+    if( num_lbl ){ hclone.prepend(num_lbl); }
     hclone.children().last().remove(); // remove only the last child 
     a.html(hclone.html());
     a.on('click',function(){setTimeout(function(){ $.ajax()}, 100) }) //workaround for  https://github.com/jupyter/notebook/issues/699
@@ -98,9 +103,9 @@ define(["require", "jquery", "base/js/namespace",  'services/config',
         .text("[-]")
         .click( function(){
             $('#toc').slideToggle({'complete': function(){
-		    IPython.notebook.metadata.toc['toc_section_display']=$('#toc').css('display');
-		    IPython.notebook.set_dirty();}}
-		    );
+            IPython.notebook.metadata.toc['toc_section_display']=$('#toc').css('display');
+            IPython.notebook.set_dirty();}}
+            );
             $('#toc-wrapper').toggleClass('closed');
             if ($('#toc-wrapper').hasClass('closed')){
               $('#toc-wrapper .hide-btn')
@@ -135,7 +140,7 @@ define(["require", "jquery", "base/js/namespace",  'services/config',
         .click( function(){
           number_sections=!(number_sections); 
           IPython.notebook.metadata.toc['toc_number_sections']=number_sections;
-	  IPython.notebook.set_dirty();
+          IPython.notebook.set_dirty();
           table_of_contents();
           return false;
         })
@@ -150,8 +155,8 @@ define(["require", "jquery", "base/js/namespace",  'services/config',
         .attr('title', 'Add a toc section in Notebook')
         .click( function(){
           toc_cell=!(toc_cell); 
-	  IPython.notebook.metadata.toc['toc_cell']=toc_cell;
-	  IPython.notebook.set_dirty();
+          IPython.notebook.metadata.toc['toc_cell']=toc_cell;
+          IPython.notebook.set_dirty();
           table_of_contents();
           return false;
         })
@@ -168,13 +173,13 @@ define(["require", "jquery", "base/js/namespace",  'services/config',
               $(this).width($(this).width());
           },
           stop :  function (event,ui){ // on save, store toc position
-		IPython.notebook.metadata['toc_position']={
-		'left':$('#toc-wrapper').css('left'), 
-		'top':$('#toc-wrapper').css('top'),
+        IPython.notebook.metadata['toc_position']={
+        'left':$('#toc-wrapper').css('left'), 
+        'top':$('#toc-wrapper').css('top'),
         'width':$('#toc-wrapper').css('width'),  
-		'right':$('#toc-wrapper').css('right')};
-		IPython.notebook.set_dirty();
-		},
+        'right':$('#toc-wrapper').css('right')};
+        IPython.notebook.set_dirty();
+        },
     }); 
 
     $('#toc-wrapper').resizable({
@@ -182,13 +187,13 @@ define(["require", "jquery", "base/js/namespace",  'services/config',
               $(this).width($(this).width());
           },
           stop :  function (event,ui){ // on save, store toc position
-		IPython.notebook.metadata['toc_position']={
-		'left':$('#toc-wrapper').css('left'), 
-		'top':$('#toc-wrapper').css('top'),
+        IPython.notebook.metadata['toc_position']={
+        'left':$('#toc-wrapper').css('left'), 
+        'top':$('#toc-wrapper').css('top'),
         'width':$('#toc-wrapper').css('width'),  
-		'right':$('#toc-wrapper').css('right')};
-		IPython.notebook.set_dirty();
-		},
+        'right':$('#toc-wrapper').css('right')};
+        IPython.notebook.set_dirty();
+        },
     });
 
     // restore toc position at load
@@ -202,16 +207,14 @@ define(["require", "jquery", "base/js/namespace",  'services/config',
     if (IPython.notebook.metadata.toc !== undefined) {
         if (IPython.notebook.metadata.toc['toc_section_display']!==undefined)    
             $('#toc').css('display',IPython.notebook.metadata.toc['toc_section_display'])
-        if (IPython.notebook.metadata.toc['toc_window_display']!==undefined)    { 
+        if (IPython.notebook.metadata.toc['toc_window_display']!==undefined) {
             console.log("Restoring toc display"); 
-            $('#toc-wrapper').css('display',IPython.notebook.metadata.toc['toc_window_display'] ? 'block' : 'none')}
+            $('#toc-wrapper').css('display',IPython.notebook.metadata.toc['toc_window_display']?'block':'none')}
     }
     
     // if toc-wrapper is undefined (first run(?), then hide it)
     if ($('#toc-wrapper').css('display')==undefined) $('#toc-wrapper').css('display',"none") //block
   };
-
-
 
 //  var table_of_contents = function (threshold) { //small bug because being called on an event, the passed threshold was actually an event
 //                                                   now threshold is a global variable 
@@ -219,18 +222,15 @@ var table_of_contents = function () {
     if(rendering_toc_cell) { // if toc_cell is rendering, do not call  table_of_contents,                             
         rendering_toc_cell=false;  // otherwise it will loop
         return}
-//
+
     var toc_wrapper = $("#toc-wrapper");
-  
-//
     var toc_index=0;
     if (toc_wrapper.length === 0) {
       create_toc_div();
     }
     var segments = [];
-    var ol = $("<ol/>");
-    ol.addClass("toc-item");
-    $("#toc").empty().append(ol);
+    var ul = $("<ul/>").addClass("toc-item");
+    $("#toc").empty().append(ul);
 
    // TOC CELL -- if toc_cell=true, add and update a toc cell in the notebook. 
    //             This cell, initially at the very beginning, can be moved.
@@ -238,7 +238,6 @@ var table_of_contents = function () {
    //             Optionnaly, the sections in the toc can be numbered.
                
    var cell_toc = undefined;
-
    function look_for_cell_toc(callb){ // look for a possible toc cell
        var cells = IPython.notebook.get_cells();
        var lcells=cells.length;
@@ -247,21 +246,21 @@ var table_of_contents = function () {
                 cell_toc=cells[i]; 
                 toc_index=i; 
                 //console.log("Found a cell_toc",i); 
-                break;}	
+                break;} 
                 }
     callb && callb(i);
     }
     // then process the toc cell:
     function proces_cell_toc(i){ 
-	    //if toc_cell=true, we want a cell_toc. 
-	    //	If it does not exist, create it at the beginning of the notebook
-	    //if toc_cell=false, we do not want a cell-toc. 
-	    //	If one exists, delete it
+        //if toc_cell=true, we want a cell_toc. 
+        //  If it does not exist, create it at the beginning of the notebook
+        //if toc_cell=false, we do not want a cell-toc. 
+        //  If one exists, delete it
         if(toc_cell) {
                if (cell_toc == undefined) {
                     rendering_toc_cell = true;
                     //console.log("*********  Toc undefined - Inserting toc_cell");
-	        	    cell_toc = IPython.notebook.select(0).insert_cell_above("markdown"); 
+                    cell_toc = IPython.notebook.select(0).insert_cell_above("markdown"); 
                     cell_toc.metadata.toc="true";
                }
         }
@@ -274,77 +273,60 @@ var table_of_contents = function () {
     //proces_cell_toc();
     
     var cell_toc_text = "# Table of Contents\n <p>";
-    var depth = 1;
-    var li;
-    $("#notebook").find(":header").map(function (i, h) {
-      var level = parseInt(h.tagName.slice(1), 10);
+    var depth = 1; //var depth = ol_depth(ol);
+    var li= ul;//yes, initialize li with ul! 
+    var all_headers= $("#notebook").find(":header");
+    var min_lvl=1, lbl_ary= [];
+    for(; min_lvl <= 6; min_lvl++){ if(all_headers.is('h'+min_lvl)){break;} }
+    for(var i= min_lvl; i <= 6; i++){ lbl_ary[i - min_lvl]= 0; }
+
+    //loop over all headers
+    all_headers.each(function (i, h) {
+      var level = parseInt(h.tagName.slice(1), 10) - min_lvl + 1;
       // skip below threshold
-      if (level > threshold) return;
+      if (level > threshold){ return; }
       // skip headings with no ID to link to
-      if (!h.id) return;
+      if (!h.id){ return; }
       // skip toc cell if present
-      if (h.id=="Table-of-Contents") return;
-      
-      //var depth = ol_depth(ol);
+      if (h.id=="Table-of-Contents"){ return; }
+      //If h had already a number, remove it
+      $(h).find(".toc-item-num").remove();
+      var num_str= incr_lbl(lbl_ary,level-1).join('.');// numbered heading labels
+      var num_lbl= $("<span/>").addClass("toc-item-num")
+            .text(num_str).append('&nbsp;').append('&nbsp;');
 
       // walk down levels
-      for (; depth < level; depth++) {
-        var new_ol = $("<ol/>");
-        new_ol.addClass("toc-item");
-        li.append(new_ol);
-        ol = new_ol;
+      for(var elm=li; depth < level; depth++) {
+          var new_ul = $("<ul/>").addClass("toc-item");
+          elm.append(new_ul);
+          elm= ul= new_ul;
       }
       // walk up levels
-      for (; depth > level; depth--) {
-          // up twice: the enclosing <ol> and the <li> it was  inserted in 
-          ol = ol.parent().parent();
+      for(; depth > level; depth--) {
+          // up twice: the enclosing <ol> and <li> it was inserted in
+          ul= ul.parent();
+          while(!ul.is('ul')){ ul= ul.parent(); }
       }
-      //
-      $(h).find(".toc-item-num").remove(); //If h had already a number, remove it
-      li=$("<li/>").append(make_link($(h)));
-      ol.append(li);
-      
 
+      // Create toc entry, append <li> tag to the current <ol>. Prepend numbered-labels to headings.
+      li=$("<li/>").append( make_link( $(h), num_lbl));
+      ul.append(li);
+      if( number_sections ){ $(h).prepend(num_lbl); }
 
-    // Add numerotation of sections if number_sections==true
-    // adapted from from http://stackoverflow.com/questions/5127017/automatic-numbering-of-headings-h1-h6-using-jquery
-    if (number_sections){
-      if(segments.length == level) {
-        // from Hn to another Hn, just increment the last segment
-        segments[level-1]++;
-      } else if(segments.length > level) {
-        // from Hn to Hn-x, slice off the last x segments, and increment the last of the remaining
-        segments = segments.slice(0, level);
-        segments[level-1]++;
-      } else if(segments.length < level) {
-        // from Hn to Hn+x, (should always be Hn+1, but some error checks anyway)
-        // add '0' (x-1) times, then a 1
-        var deltalevel = level-segments.length   
-        for(var i = 0; i < (deltalevel-1); i++) {
-          segments.push(0);
-        }
-        segments.push(1);
+      //toc_cell:
+      if(toc_cell) {
+          var tabs = function(level) {
+                var tabs = '';
+                for (var j = 0; j < level -1; j++) { 
+                  tabs += "\t";}
+                  return tabs}
+
+          var leves='<div class="lev'+level.toString()+'">'
+          var lnk=make_link($(h))
+          cell_toc_text += leves + $('<p>').append(lnk).html()+'</div>';
+          //workaround for https://github.com/jupyter/notebook/issues/699 as suggested by @jhamrick
+          lnk.on('click',function(){setTimeout(function(){console.log('clicked'); $.ajax()}, 100) }) 
       }
-      var num=$("<span/>").addClass("toc-item-num").text(segments.join(".")+" - ");
-      //$(h).find(".toc-item-num").remove(); //If h had already a number, remove it
-      $(h).prepend(num);
-}
-    //---------------------------
-//toc_cell:
-if(toc_cell) {
-    var tabs = function(level) {
-          var tabs = '';
-          for (var j = 0; j < level -1; j++) { 
-		    tabs += "\t";}
-            return tabs}
-
-    var leves='<div class="lev'+level.toString()+'">'
-    var lnk=make_link($(h))
-    cell_toc_text += leves + $('<p>').append(lnk).html()+'</div>';
-    lnk.on('click',function(){setTimeout(function(){console.log('clicked'); $.ajax()}, 100) })  //workaround for  https://github.com/jupyter/notebook/issues/699
-                                                                                        //as suggested by @jhamrick
-    }
-
     });
 
     if(toc_cell) {
@@ -352,23 +334,22 @@ if(toc_cell) {
          //IPython.notebook.to_markdown(toc_index);
          cell_toc.set_text(cell_toc_text); 
          cell_toc.render();
-};
-
+    };
 
     $(window).resize(function(){
-      $('#toc').css({maxHeight: $(window).height() - 200});
+        $('#toc').css({maxHeight: $(window).height() - 200});
     });
 
     $(window).trigger('resize');
-  };
+};
     
   var toggle_toc = function () {
     // toggle draw (first because of first-click behavior)
     $("#toc-wrapper").toggle({'complete':function(){
-		IPython.notebook.metadata.toc['toc_window_display']=$('#toc-wrapper').css('display')=='block';
-					} 
-		});
-     IPython.notebook.set_dirty();
+        IPython.notebook.metadata.toc['toc_window_display']=$('#toc-wrapper').css('display')=='block';
+      }
+    });
+    IPython.notebook.set_dirty();
     // recompute:
     rendering_toc_cell = false;
     table_of_contents();
@@ -407,32 +388,30 @@ if(toc_cell) {
                                                        // thus I rely on kernel_ready.Kernel to read the initial config 
                                                        // and render the first  table of contents
             read_config(); 
-	    table_of_contents(); 
-	    // render toc for each markdown cell modification
-	    //$([IPython.events]).on("rendered.MarkdownCell", table_of_contents);
-	    $([IPython.events]).on("rendered.MarkdownCell", function(){table_of_contents();});
+        table_of_contents(); 
+        // render toc for each markdown cell modification
+        //$([IPython.events]).on("rendered.MarkdownCell", table_of_contents);
+        $([IPython.events]).on("rendered.MarkdownCell", function(){table_of_contents();});
             console.log("toc2 initialized (via notebook_loaded)")
-	    extension_initialized=true	; // flag to indicate that initialization was done
+        extension_initialized=true  ; // flag to indicate that initialization was done
 })
 
     $([IPython.events]).on("kernel_ready.Kernel", function(){
-            if (!extension_initialized){
+        if (!extension_initialized){
             read_config(); 
-	    table_of_contents(); 
-	    // render toc for each markdown cell modification
-	    $([IPython.events]).on("rendered.MarkdownCell", function(){table_of_contents();});
+            table_of_contents(); 
+            // render toc for each markdown cell modification
+            $([IPython.events]).on("rendered.MarkdownCell", function(){table_of_contents();});
             console.log("toc2 initialized (via kernel_ready)")
-	}
-   });
+        }
+    });
 
   };
-
 
   return {
     load_ipython_extension : load_ipython_extension,
     toggle_toc : toggle_toc,
     table_of_contents : table_of_contents
-    
   };
 
 });


### PR DESCRIPTION
* Table of Contents was empty when the first heading is `<h2>` or higher.
* TOC had incorrectly numbered labels when some heading levels are skipped over.
* Make calculations of numbered labels more robust.
* Minor code cleanup