### PR TITLE
updates to `nbextensions/usability/collapsible_headings`:

### DIFF
--- a/nbextensions/usability/collapsible_headings/collapsible_headings.yaml
+++ b/nbextensions/usability/collapsible_headings/collapsible_headings.yaml
@@ -32,6 +32,14 @@ Parameters:
   description: Adjust the size of the toggle controls to match their heading levels
   input_type: checkbox
   default: false
+- name: collapsible_headings_show_section_brackets
+  description: show Mathematica-style brackets around each collapsible section
+  input_type: checkbox
+  default: false
+- name: collapsible_headings_show_ellipsis
+  description: show a gray bracketed ellipsis at the end of collapsed heading cells
+  input_type: checkbox
+  default: true
 - name: collapsible_headings_use_shortcuts
   description: Add command-mode keyboard shortcuts to collapse/uncollapse the selected heading cell
   input_type: checkbox

--- a/nbextensions/usability/collapsible_headings/collapsible_headings.yaml
+++ b/nbextensions/usability/collapsible_headings/collapsible_headings.yaml
@@ -11,9 +11,27 @@ Parameters:
   input_type: checkbox
   default: false
 - name: collapsible_headings_use_toggle_controls
-  description: Add a button in each heading cell's input prompt to collapse/uncollapse it
+  description: Add a control in each heading cell's input prompt to collapse/uncollapse it
   input_type: checkbox
   default: true
+- name: collapsible_headings_toggle_color
+  description: Color for the toggle control icon
+  input_type: color
+  default: '#aaa'
+- name: collapsible_headings_toggle_closed_icon
+  description: font-awesome class for the toggle control icon on collapsed headings
+  default: fa-caret-right
+- name: collapsible_headings_toggle_open_icon
+  description: font-awesome class for the toggle control icon on uncollapsed (expanded) headings
+  default: fa-caret-down
+- name: collapsible_headings_make_toggle_controls_buttons
+  description: "Make the toggle control into a button (if false, it's just an icon)"
+  input_type: checkbox
+  default: false
+- name: collapsible_headings_size_toggle_controls_by_level
+  description: Adjust the size of the toggle controls to match their heading levels
+  input_type: checkbox
+  default: false
 - name: collapsible_headings_use_shortcuts
   description: Add command-mode keyboard shortcuts to collapse/uncollapse the selected heading cell
   input_type: checkbox

--- a/nbextensions/usability/collapsible_headings/collapsible_headings.yaml
+++ b/nbextensions/usability/collapsible_headings/collapsible_headings.yaml
@@ -10,6 +10,10 @@ Parameters:
   description: Add a toolbar button to collapse the closest header cell
   input_type: checkbox
   default: false
+- name: collapsible_headings_use_toggle_controls
+  description: Add a button in each heading cell's input prompt to collapse/uncollapse it
+  input_type: checkbox
+  default: true
 - name: collapsible_headings_use_shortcuts
   description: Add command-mode keyboard shortcuts to collapse/uncollapse the selected heading cell
   input_type: checkbox

--- a/nbextensions/usability/collapsible_headings/main.css
+++ b/nbextensions/usability/collapsible_headings/main.css
@@ -29,7 +29,7 @@
 	transform: none;
 }
 
-.input_prompt {
+.text_cell .input_prompt {
 	display: flex;
     flex-direction: row;
 }

--- a/nbextensions/usability/collapsible_headings/main.css
+++ b/nbextensions/usability/collapsible_headings/main.css
@@ -38,3 +38,66 @@
 	flex: 1;
     align-self: center;
 }
+
+/* bracket rules */
+
+div.cell {
+  position: relative;
+}
+
+.chb {
+  position: absolute;
+  top: -1px;
+  bottom: -1px;
+  left: calc(100% + 3px);
+  display: flex;
+  flex-direction: row-reverse;
+  justify-content: flex-start;
+  align-items: stretch;
+}
+
+.chb div {
+  margin-left: 2px;
+  width: 5px;
+  border-color: #aaa;
+  border-style: solid;
+  border-width: 0 1px 0 0;
+}
+
+.chb .chb-start {
+  border-top-width: 1px;
+  margin-top: 2px;
+}
+
+.chb .chb-end {
+  border-bottom-width: 1px;
+  margin-bottom: 2px;
+}
+
+.collapsible_headings_collapsed .chb .chb-start {
+	border-width: 5px 2px 2px 0;
+}
+
+/* ellipsis rules */
+.collapsible_headings_ellipsis .rendered_html h1,
+.collapsible_headings_ellipsis .rendered_html h2,
+.collapsible_headings_ellipsis .rendered_html h3,
+.collapsible_headings_ellipsis .rendered_html h4,
+.collapsible_headings_ellipsis .rendered_html h5,
+.collapsible_headings_ellipsis .rendered_html h6 {
+  position: relative;
+  padding-right: 2em;
+}
+
+.collapsible_headings_collapsed.collapsible_headings_ellipsis .rendered_html h1:after,
+.collapsible_headings_collapsed.collapsible_headings_ellipsis .rendered_html h2:after,
+.collapsible_headings_collapsed.collapsible_headings_ellipsis .rendered_html h3:after,
+.collapsible_headings_collapsed.collapsible_headings_ellipsis .rendered_html h4:after,
+.collapsible_headings_collapsed.collapsible_headings_ellipsis .rendered_html h5:after,
+.collapsible_headings_collapsed.collapsible_headings_ellipsis .rendered_html h6:after {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  content: "[\002026]";
+  color: #aaa;
+}

--- a/nbextensions/usability/collapsible_headings/main.css
+++ b/nbextensions/usability/collapsible_headings/main.css
@@ -28,3 +28,13 @@
 	-o-transform: none;
 	transform: none;
 }
+
+.input_prompt {
+	display: flex;
+    flex-direction: row;
+}
+
+.collapsible_headings_toggle {
+	flex: 1;
+    align-self: center;
+}

--- a/nbextensions/usability/collapsible_headings/readme.md
+++ b/nbextensions/usability/collapsible_headings/readme.md
@@ -14,11 +14,34 @@ The extension offers a few options for how to expand and collapse headings,
 each of which can be enabled or disabled from the nbextensions config page:
 
 * Command-mode keyboard shortcuts, (enabled by default, and set to left and
-  right arrow keys, but bindings are also configurable from the config page).
-* A toggle button in the input prompt area of each heading cell (as seen in the
-  screenshot below, enabled by default)
+  right arrow keys, but bindings are also configurable from the config page)
+* A toggle control in the input prompt area of each heading cell (as seen in
+  the screenshot below, enabled by default)
+  * Configurable icons and icon color for the toggle control (by default, grey
+    right/down carets are used)
+  * The option to make the toggle control into a button (by default it's just a
+    clickable icon)
 * A toolbar button to collapse the nearest heading to the curently selected
   cell (disabled by default)
+
+
+css
+===
+
+The extension add the css class `collapsible_headings_collapsed` to each
+collapsed heading cell, which you could use for custom css rules, such as
+adding a bottom border to collapsed headings, to visually distinguish them a
+bit more.
+
+The toggle controls' icons currently spin when the heading gets collapsed or
+uncollapsed, via a css transition property. If this annoys you, you could turn
+it off using the following rule in your custom css:
+
+```css
+.cell .collapsible_headings_toggle .fa:before {
+	transition: transform 0s;
+}
+```
 
 ![screenshot](screenshot.png)
 

--- a/nbextensions/usability/collapsible_headings/readme.md
+++ b/nbextensions/usability/collapsible_headings/readme.md
@@ -10,8 +10,9 @@ and reloaded on notebook load.
 Options
 =======
 
-The extension offers a few options for how to expand and collapse headings,
-each of which can be enabled or disabled from the nbextensions config page:
+The extension offers a few options for how to display and toggle the collapsed
+status of headings, each of which can be enabled, disabled or configured from
+the nbextensions config page:
 
 * Command-mode keyboard shortcuts, (enabled by default, and set to left and
   right arrow keys, but bindings are also configurable from the config page)
@@ -21,6 +22,11 @@ each of which can be enabled or disabled from the nbextensions config page:
     right/down carets are used)
   * The option to make the toggle control into a button (by default it's just a
     clickable icon)
+* Mathematica-style grouping brackets around each collapsible section on the
+  right of the notebook, clickable to toggle the relevant section (disabled by
+  default)
+* A gray bracketed ellipsis added to the end of each collapsed heading,
+  indicating hidden content (disabled by default)
 * A toolbar button to collapse the nearest heading to the curently selected
   cell (disabled by default)
 
@@ -33,9 +39,9 @@ collapsed heading cell, which you could use for custom css rules, such as
 adding a bottom border to collapsed headings, to visually distinguish them a
 bit more.
 
-The toggle controls' icons currently spin when the heading gets collapsed or
-uncollapsed, via a css transition property. If this annoys you, you could turn
-it off using the following rule in your custom css:
+The toggle controls' icons currently spin by 360 degrees when the heading gets
+collapsed or uncollapsed, via a css transition property. If this annoys you,
+you could turn it off using the following rule in your custom css:
 
 ```css
 .cell .collapsible_headings_toggle .fa:before {

--- a/nbextensions/usability/collapsible_headings/readme.md
+++ b/nbextensions/usability/collapsible_headings/readme.md
@@ -1,19 +1,26 @@
 Allows notebook to have collapsible sections, separated by headings.
 
 Any markdown heading cell (that is, one which begins with 1-6 `#` characters),
-becomes collapsible, with a button in the margin of the header to
-collapse/expand the cell:
-
-![screenshot](screenshot.png)
+becomes collapsible once rendered.
 
 The collapsed/expanded status of the headings is stored in the cell metadata,
 and reloaded on notebook load.
 
-In addition, the extension offers an optional toolbar button to collapse the
-nearest heading to the curently selected cell, plus optional configurable
-command-mode keyboard shortcuts to collapse and uncollapse headings, by default
-set to left and right arrow keys.
 
+Options
+=======
+
+The extension offers a few options for how to expand and collapse headings,
+each of which can be enabled or disabled from the nbextensions config page:
+
+* Command-mode keyboard shortcuts, (enabled by default, and set to left and
+  right arrow keys, but bindings are also configurable from the config page).
+* A toggle button in the input prompt area of each heading cell (as seen in the
+  screenshot below, enabled by default)
+* A toolbar button to collapse the nearest heading to the curently selected
+  cell (disabled by default)
+
+![screenshot](screenshot.png)
 
 
 Internals
@@ -23,9 +30,29 @@ Heading cells which are collapsed have a value set in the cell metadata, so
 that
 
 ```javascript
-cell.metadata.collapsible_heading_collapsed = true
+cell.metadata.heading_collapsed = true
 ```
 
-This could be used in an nbconvert preprocessor, but I
+The extension patches some Jupyter methods:
+* `TextCell.prototype.execute` is patched to add/remove the toggle buttons,
+  as well as update the visibility of any cells below the new one.
+* `Notebook.prototype.select` is patched to make sure any collapsed headings
+  which would be hiding the new selection get uncollapsed (expanded).
+* `Notebook.prototype.undelete` and `Notebook.prototype.delete_cells` are
+  patched to trigger an update of which cells should be visible or hidden.
+
+The extension also patches two existing Jupyter actions: those triggered in
+command mode by the up/down arrow keys. Ordinarily, these select the cell
+above/below the current selection. Once patched by `collapsible_headings`, they
+have the same behaviour, but skip over any cells which have been hidden (by a
+collapsed heading, or, in fact, by any other mechanism).
+
+Finally, `collapsible_headings` registers two new actions, namely
+`collapsible_headings:collapse_heading` and
+`collapsible_headings:uncollapse_heading`, which are used by the keyboard
+shortcuts (if used), and can be called as with any other action.
+
+This could be used in an nbconvert preprocessor, as in the older
+hierarchical_collapse extension but I
 ([@jcb91](https://github.com/jcb91)) haven't written one.
 If you'd like one, feel free to get in touch to ask for it!


### PR DESCRIPTION
* Make the heading toggle buttons optional. This also necessitates registering existing cells only after config has loaded
* add `collapsible_headings_collapsed` css class to the cell, rather than the toggle button
* remove `cell.metadata.heading_collapsed` value from non-heading cells
* update readme