### PR TITLE
Fixed toc window resizing issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+*~
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/nbextensions/usability/codefolding/firstline-fold.js
+++ b/nbextensions/usability/codefolding/firstline-fold.js
@@ -5,10 +5,10 @@ CodeMirror.registerHelper("fold", "firstline", function(cm, start) {
       var lineText = cm.getLine(start.line);
       var found = lineText.lastIndexOf(Token,0);
       if (found == 0) {
-        end =  cm.lastLine(); 
+        end =  cm.lastLine();
         return {from: CodeMirror.Pos(start.line, null),
-              to: CodeMirror.Pos(end, null)}; 
+              to: CodeMirror.Pos(end, null)};
         }
     }
-    return ;  
+    return ;
 });

--- a/nbextensions/usability/codefolding/main.js
+++ b/nbextensions/usability/codefolding/main.js
@@ -118,10 +118,10 @@ define([
                 var found = jQuery.inArray("CodeMirror-foldgutter", gutters);
                 if ( found == -1) {
                     cell.code_mirror.setOption('gutters', [ gutters , "CodeMirror-foldgutter"]);
-                }            
+                }
         }
     }
-    
+
     /**
      * Add codefolding gutter to a new cell
      *
@@ -162,7 +162,7 @@ define([
                             break;
                         }
                         cell.code_mirror.refresh();
-                    }            
+                    }
                 }
             cell.code_mirror.on('fold',updateMetadata);
             cell.code_mirror.on('unfold',updateMetadata);
@@ -183,19 +183,19 @@ define([
         link.rel = "stylesheet";
         link.href = require.toUrl(name, 'css');
         document.getElementsByTagName("head")[0].appendChild(link);
-    };    
+    };
 
     /**
      * Initialize extension
      *
      */
-    var load_extension = function() { 
+    var load_extension = function() {
         load_css('codemirror/addon/fold/foldgutter.css');
         /* change default gutter width */
         load_css( './foldgutter.css');
-        /* additional custom codefolding mode */
-        require(['./firstline-fold']);
-        setTimeout(initGutter, 100)
+        /* require our additional custom codefolding modes before initialising
+           fully */
+        require(['./firstline-fold', './magic-fold'], initGutter);
         };
 
     return {load_ipython_extension : load_extension};

--- a/nbextensions/usability/collapsible_headings/main.css
+++ b/nbextensions/usability/collapsible_headings/main.css
@@ -1,10 +1,24 @@
-.collapsible_headings_toggle .h1,
-.collapsible_headings_toggle .h2,
-.collapsible_headings_toggle .h3,
+.collapsible_headings_toggle .h1 {
+  font-size: 185.7%;
+  margin: 0.538em 0 0 0;
+  line-height: 1.0;
+}
+.collapsible_headings_toggle .h2 {
+  font-size: 157.1%;
+  margin: 0.636em 0 0 0;
+  line-height: 1.0;
+}
+.collapsible_headings_toggle .h3 {
+  font-size: 128.6%;
+  margin: 0.777em 0 0 0;
+  line-height: 1.0;
+}
 .collapsible_headings_toggle .h4,
 .collapsible_headings_toggle .h5,
 .collapsible_headings_toggle .h6 {
-	margin: 0;
+  font-size: 100%;
+  margin: 1em 0 0 0;
+  line-height: 1.0;
 }
 
 .collapsible_headings_toggle .fa:before {
@@ -27,16 +41,6 @@
 	-ms-transform: none;
 	-o-transform: none;
 	transform: none;
-}
-
-.text_cell .input_prompt {
-	display: flex;
-    flex-direction: row;
-}
-
-.collapsible_headings_toggle {
-	flex: 1;
-    align-self: center;
 }
 
 /* bracket rules */
@@ -75,7 +79,7 @@ div.cell {
 }
 
 .collapsible_headings_collapsed .chb .chb-start {
-	border-width: 5px 2px 2px 0;
+  border-width: 5px 2px 2px 0;
 }
 
 /* ellipsis rules */

--- a/nbextensions/usability/toc2/README.md
+++ b/nbextensions/usability/toc2/README.md
@@ -35,4 +35,5 @@ from https://gist.github.com/magican/5574556
 - @JanSchulz, (enable maths in headers links)
 - @jfbercher december 06, 2015 -- (automatic numbering, toc cell, window dragging, configuration parameters)
 - @jfbercher december 24, 2015 -- nested numbering in toc-window, following the fix by [@paulovn](https://github.com/minrk/ipython_extensions/pull/53) in @minrk's repo. December 30-31, updated config in toc2.yaml to enable choosing the initial visible state of toc_window via a checkbox ; and now resizable. 
-
+- @slonik-az february 13, 2016. rewritten toc numberings (more robust version), fiwed problems with skipped heading levels, some code cleanup
+- @jfbercher february 21, 2016. Fixed some issues when resizing the toc window. Now avoid overflows, clip the text and add a scrollbar. 

--- a/nbextensions/usability/toc2/main.css
+++ b/nbextensions/usability/toc2/main.css
@@ -1,10 +1,14 @@
 /*extracted from https://gist.github.com/magican/5574556*/
 
 #toc {
+<<<<<<< HEAD
   overflow-y: auto;
+=======
+>>>>>>> 2fef1e6372a7f553e2d1c6632f7f6bc6e30bb998
   max-height: 500px;
   padding: 0px;
-}
+  overflow-y: auto;
+} 
 
 #toc  ol.toc-item {
     counter-reset: item;
@@ -41,11 +45,13 @@
   background-color: #fff;
   opacity: .8;
   z-index: 100;
+  overflow: hidden;
 }
 
 #toc-wrapper.closed {
   min-width: 100px;
   width: auto;
+  height:auto;
   transition: width;
 }
 #toc-wrapper:hover{

--- a/nbextensions/usability/toc2/main.css
+++ b/nbextensions/usability/toc2/main.css
@@ -2,7 +2,7 @@
 
 #toc {
   overflow-y: auto;
-  max-height: 300px;
+  max-height: 500px;
   padding: 0px;
 }
 
@@ -16,6 +16,12 @@
     display: block;
   }
 
+#toc ul.toc-item {
+    list-style-type: none;
+    padding: 0;
+    margin:  0;
+}
+
 #toc  ol.toc-item li:before {
     font-size: 90%;
     font-family: Georgia, Times New Roman, Times, serif;
@@ -27,7 +33,7 @@
 #toc-wrapper {
   position: fixed;
   top: 120px;
-  max-width:300px;
+  max-width:600px;
   right: 20px;
   border: thin solid rgba(0, 0, 0, 0.38);
   border-radius: 5px;
@@ -78,6 +84,12 @@
     font-style: normal;
 }
 
+#toc-wrapper .toc-item-num {
+    font-style: normal;
+    font-family: Georgia, Times New Roman, Times, serif;
+    color: black;
+}
+
 .lev1 {margin-left: 80px}
 .lev2 {margin-left: 100px}
 .lev3 {margin-left: 120px}
@@ -86,3 +98,4 @@
 .lev6 {margin-left: 180px}
 .lev7 {margin-left: 200px}
 .lev8 {margin-left: 220px}
+

--- a/nbextensions/usability/toc2/main.js
+++ b/nbextensions/usability/toc2/main.js
@@ -59,6 +59,7 @@ define(["require", "jquery", "base/js/namespace",  'services/config',
     var extension_initialized=false;
 
 //......... utilitary functions............
+<<<<<<< HEAD
 
   function incr_lbl(ary, h_idx){//increment heading label  w/ h_idx (zero based)
       ary[h_idx]++;
@@ -66,6 +67,15 @@ define(["require", "jquery", "base/js/namespace",  'services/config',
       return ary.slice(0, h_idx+1);
   }
 
+=======
+
+  function incr_lbl(ary, h_idx){//increment heading label  w/ h_idx (zero based)
+      ary[h_idx]++;
+      for(var j= h_idx+1; j < ary.length; j++){ ary[j]= 0; }
+      return ary.slice(0, h_idx+1);
+  }
+
+>>>>>>> 2fef1e6372a7f553e2d1c6632f7f6bc6e30bb998
   var make_link = function (h, num_lbl) {
     var a = $("<a/>");
     a.attr("href", '#' + h.attr('id'));
@@ -108,10 +118,13 @@ define(["require", "jquery", "base/js/namespace",  'services/config',
             );
             $('#toc-wrapper').toggleClass('closed');
             if ($('#toc-wrapper').hasClass('closed')){
+              $('#toc-wrapper').css({height: 40});
               $('#toc-wrapper .hide-btn')
               .text('[+]')
               .attr('title', 'Show ToC');
             } else {
+              $('#toc-wrapper').css({height: IPython.notebook.metadata.toc_position['height']});
+              $('#toc').css({height: IPython.notebook.metadata.toc_position['height']});
               $('#toc-wrapper .hide-btn')
               .text('[-]')
               .attr('title', 'Hide ToC');
@@ -173,6 +186,7 @@ define(["require", "jquery", "base/js/namespace",  'services/config',
               $(this).width($(this).width());
           },
           stop :  function (event,ui){ // on save, store toc position
+<<<<<<< HEAD
         IPython.notebook.metadata['toc_position']={
         'left':$('#toc-wrapper').css('left'), 
         'top':$('#toc-wrapper').css('top'),
@@ -180,6 +194,22 @@ define(["require", "jquery", "base/js/namespace",  'services/config',
         'right':$('#toc-wrapper').css('right')};
         IPython.notebook.set_dirty();
         },
+=======
+        var oldHeight = IPython.notebook.metadata['toc_position']['height'];
+		IPython.notebook.metadata['toc_position']={
+		'left':$('#toc-wrapper').css('left'), 
+		'top':$('#toc-wrapper').css('top'),
+        'width':$('#toc-wrapper').css('width'),  
+		'right':$('#toc-wrapper').css('right')};
+        if (!$('#toc-wrapper').hasClass('closed')){
+            IPython.notebook.metadata['toc_position']['height']=$('#toc-wrapper').css('height');
+        }
+        else {
+            IPython.notebook.metadata['toc_position']['height']=oldHeight;
+        }
+		IPython.notebook.set_dirty();
+		},
+>>>>>>> 2fef1e6372a7f553e2d1c6632f7f6bc6e30bb998
     }); 
 
     $('#toc-wrapper').resizable({
@@ -191,10 +221,20 @@ define(["require", "jquery", "base/js/namespace",  'services/config',
         'left':$('#toc-wrapper').css('left'), 
         'top':$('#toc-wrapper').css('top'),
         'width':$('#toc-wrapper').css('width'),  
+<<<<<<< HEAD
         'right':$('#toc-wrapper').css('right')};
         IPython.notebook.set_dirty();
         },
     });
+=======
+        'height':$('#toc-wrapper').css('height'), 
+		'right':$('#toc-wrapper').css('right')};
+        $('#toc').css('height', $('#toc-wrapper').height()-30)
+		IPython.notebook.set_dirty();
+		},
+    }); 
+ 
+>>>>>>> 2fef1e6372a7f553e2d1c6632f7f6bc6e30bb998
 
     // restore toc position at load
     if (IPython.notebook.metadata['toc_position'] !== undefined){
@@ -205,11 +245,28 @@ define(["require", "jquery", "base/js/namespace",  'services/config',
 
     // Restore toc display 
     if (IPython.notebook.metadata.toc !== undefined) {
-        if (IPython.notebook.metadata.toc['toc_section_display']!==undefined)    
+        if (IPython.notebook.metadata.toc['toc_section_display']!==undefined)  {  
             $('#toc').css('display',IPython.notebook.metadata.toc['toc_section_display'])
+<<<<<<< HEAD
         if (IPython.notebook.metadata.toc['toc_window_display']!==undefined) {
             console.log("Restoring toc display"); 
             $('#toc-wrapper').css('display',IPython.notebook.metadata.toc['toc_window_display']?'block':'none')}
+=======
+            $('#toc').css('height', $('#toc-wrapper').height()-30)
+            if (IPython.notebook.metadata.toc['toc_section_display']=='none'){
+              $('#toc-wrapper').addClass('closed');
+              $('#toc-wrapper').css({height: 40});
+              $('#toc-wrapper .hide-btn')
+              .text('[+]')
+              .attr('title', 'Show ToC');         
+            }
+        }
+        if (IPython.notebook.metadata.toc['toc_window_display']!==undefined)    { 
+            console.log("******Restoring toc display"); 
+            $('#toc-wrapper').css('display',IPython.notebook.metadata.toc['toc_window_display'] ? 'block' : 'none');
+            //$('#toc').css('overflow','auto')
+        }
+>>>>>>> 2fef1e6372a7f553e2d1c6632f7f6bc6e30bb998
     }
     
     // if toc-wrapper is undefined (first run(?), then hide it)

--- a/nbextensions/usability/toc2/main.js
+++ b/nbextensions/usability/toc2/main.js
@@ -10,7 +10,7 @@ define(["require", "jquery", "base/js/namespace",  'services/config',
 
 // ...........Parameters configuration......................
  // define default values for config parameters if they were not present in general settings (notebook.json)
-    var cfg={'toc_threshold':4, 
+    var cfg={'toc_threshold':6, 
              'toc_number_sections':true, 
              'toc_cell':false,
              'toc_window_display':false}
@@ -18,9 +18,8 @@ define(["require", "jquery", "base/js/namespace",  'services/config',
     var toc_cell=cfg['toc_cell'];
     var number_sections = cfg['toc_number_sections'];
 
-
-   function read_config() {  // read after nb is loaded
-     // create config object to load parameters
+  function read_config() {  // read after nb is loaded
+    // create config object to load parameters
     var base_url = utils.get_body_data("baseUrl");
     var config = new configmod.ConfigSection('notebook', {base_url: base_url});
 
@@ -42,16 +41,15 @@ define(["require", "jquery", "base/js/namespace",  'services/config',
     // config may be specified at system level or at document level.
     if (IPython.notebook.metadata.toc !== undefined){ //configuration saved in nb
         console.log("config stored in nb")
-	cfg = IPython.notebook.metadata.toc;
+        cfg = IPython.notebook.metadata.toc;
         threshold = cfg['toc_threshold'];
         toc_cell=cfg['toc_cell'];
         number_sections = cfg['toc_number_sections'];
-	}
-    else {
+    } else {
         console.log("config stored in system")
-	config.load();
+        config.load();
         config.loaded.then(function() {update_params() })
-    } 
+    }
     config_loaded = true;
 }
 //.....................global variables....
@@ -60,13 +58,20 @@ define(["require", "jquery", "base/js/namespace",  'services/config',
     var config_loaded = false;
     var extension_initialized=false;
 
-//......... utilitary functions............    
+//......... utilitary functions............
 
-  var make_link = function (h) {
+  function incr_lbl(ary, h_idx){//increment heading label  w/ h_idx (zero based)
+      ary[h_idx]++;
+      for(var j= h_idx+1; j < ary.length; j++){ ary[j]= 0; }
+      return ary.slice(0, h_idx+1);
+  }
+
+  var make_link = function (h, num_lbl) {
     var a = $("<a/>");
     a.attr("href", '#' + h.attr('id'));
     // get the text *excluding* the link text, whatever it may be
     var hclone = h.clone();
+    if( num_lbl ){ hclone.prepend(num_lbl); }
     hclone.children().last().remove(); // remove only the last child 
     a.html(hclone.html());
     a.on('click',function(){setTimeout(function(){ $.ajax()}, 100) }) //workaround for  https://github.com/jupyter/notebook/issues/699
@@ -98,9 +103,9 @@ define(["require", "jquery", "base/js/namespace",  'services/config',
         .text("[-]")
         .click( function(){
             $('#toc').slideToggle({'complete': function(){
-		    IPython.notebook.metadata.toc['toc_section_display']=$('#toc').css('display');
-		    IPython.notebook.set_dirty();}}
-		    );
+            IPython.notebook.metadata.toc['toc_section_display']=$('#toc').css('display');
+            IPython.notebook.set_dirty();}}
+            );
             $('#toc-wrapper').toggleClass('closed');
             if ($('#toc-wrapper').hasClass('closed')){
               $('#toc-wrapper .hide-btn')
@@ -135,7 +140,7 @@ define(["require", "jquery", "base/js/namespace",  'services/config',
         .click( function(){
           number_sections=!(number_sections); 
           IPython.notebook.metadata.toc['toc_number_sections']=number_sections;
-	  IPython.notebook.set_dirty();
+          IPython.notebook.set_dirty();
           table_of_contents();
           return false;
         })
@@ -150,8 +155,8 @@ define(["require", "jquery", "base/js/namespace",  'services/config',
         .attr('title', 'Add a toc section in Notebook')
         .click( function(){
           toc_cell=!(toc_cell); 
-	  IPython.notebook.metadata.toc['toc_cell']=toc_cell;
-	  IPython.notebook.set_dirty();
+          IPython.notebook.metadata.toc['toc_cell']=toc_cell;
+          IPython.notebook.set_dirty();
           table_of_contents();
           return false;
         })
@@ -168,13 +173,13 @@ define(["require", "jquery", "base/js/namespace",  'services/config',
               $(this).width($(this).width());
           },
           stop :  function (event,ui){ // on save, store toc position
-		IPython.notebook.metadata['toc_position']={
-		'left':$('#toc-wrapper').css('left'), 
-		'top':$('#toc-wrapper').css('top'),
+        IPython.notebook.metadata['toc_position']={
+        'left':$('#toc-wrapper').css('left'), 
+        'top':$('#toc-wrapper').css('top'),
         'width':$('#toc-wrapper').css('width'),  
-		'right':$('#toc-wrapper').css('right')};
-		IPython.notebook.set_dirty();
-		},
+        'right':$('#toc-wrapper').css('right')};
+        IPython.notebook.set_dirty();
+        },
     }); 
 
     $('#toc-wrapper').resizable({
@@ -182,13 +187,13 @@ define(["require", "jquery", "base/js/namespace",  'services/config',
               $(this).width($(this).width());
           },
           stop :  function (event,ui){ // on save, store toc position
-		IPython.notebook.metadata['toc_position']={
-		'left':$('#toc-wrapper').css('left'), 
-		'top':$('#toc-wrapper').css('top'),
+        IPython.notebook.metadata['toc_position']={
+        'left':$('#toc-wrapper').css('left'), 
+        'top':$('#toc-wrapper').css('top'),
         'width':$('#toc-wrapper').css('width'),  
-		'right':$('#toc-wrapper').css('right')};
-		IPython.notebook.set_dirty();
-		},
+        'right':$('#toc-wrapper').css('right')};
+        IPython.notebook.set_dirty();
+        },
     });
 
     // restore toc position at load
@@ -202,16 +207,14 @@ define(["require", "jquery", "base/js/namespace",  'services/config',
     if (IPython.notebook.metadata.toc !== undefined) {
         if (IPython.notebook.metadata.toc['toc_section_display']!==undefined)    
             $('#toc').css('display',IPython.notebook.metadata.toc['toc_section_display'])
-        if (IPython.notebook.metadata.toc['toc_window_display']!==undefined)    { 
+        if (IPython.notebook.metadata.toc['toc_window_display']!==undefined) {
             console.log("Restoring toc display"); 
-            $('#toc-wrapper').css('display',IPython.notebook.metadata.toc['toc_window_display'] ? 'block' : 'none')}
+            $('#toc-wrapper').css('display',IPython.notebook.metadata.toc['toc_window_display']?'block':'none')}
     }
     
     // if toc-wrapper is undefined (first run(?), then hide it)
     if ($('#toc-wrapper').css('display')==undefined) $('#toc-wrapper').css('display',"none") //block
   };
-
-
 
 //  var table_of_contents = function (threshold) { //small bug because being called on an event, the passed threshold was actually an event
 //                                                   now threshold is a global variable 
@@ -219,18 +222,15 @@ var table_of_contents = function () {
     if(rendering_toc_cell) { // if toc_cell is rendering, do not call  table_of_contents,                             
         rendering_toc_cell=false;  // otherwise it will loop
         return}
-//
+
     var toc_wrapper = $("#toc-wrapper");
-  
-//
     var toc_index=0;
     if (toc_wrapper.length === 0) {
       create_toc_div();
     }
     var segments = [];
-    var ol = $("<ol/>");
-    ol.addClass("toc-item");
-    $("#toc").empty().append(ol);
+    var ul = $("<ul/>").addClass("toc-item");
+    $("#toc").empty().append(ul);
 
    // TOC CELL -- if toc_cell=true, add and update a toc cell in the notebook. 
    //             This cell, initially at the very beginning, can be moved.
@@ -238,7 +238,6 @@ var table_of_contents = function () {
    //             Optionnaly, the sections in the toc can be numbered.
                
    var cell_toc = undefined;
-
    function look_for_cell_toc(callb){ // look for a possible toc cell
        var cells = IPython.notebook.get_cells();
        var lcells=cells.length;
@@ -247,21 +246,21 @@ var table_of_contents = function () {
                 cell_toc=cells[i]; 
                 toc_index=i; 
                 //console.log("Found a cell_toc",i); 
-                break;}	
+                break;} 
                 }
     callb && callb(i);
     }
     // then process the toc cell:
     function proces_cell_toc(i){ 
-	    //if toc_cell=true, we want a cell_toc. 
-	    //	If it does not exist, create it at the beginning of the notebook
-	    //if toc_cell=false, we do not want a cell-toc. 
-	    //	If one exists, delete it
+        //if toc_cell=true, we want a cell_toc. 
+        //  If it does not exist, create it at the beginning of the notebook
+        //if toc_cell=false, we do not want a cell-toc. 
+        //  If one exists, delete it
         if(toc_cell) {
                if (cell_toc == undefined) {
                     rendering_toc_cell = true;
                     //console.log("*********  Toc undefined - Inserting toc_cell");
-	        	    cell_toc = IPython.notebook.select(0).insert_cell_above("markdown"); 
+                    cell_toc = IPython.notebook.select(0).insert_cell_above("markdown"); 
                     cell_toc.metadata.toc="true";
                }
         }
@@ -274,77 +273,60 @@ var table_of_contents = function () {
     //proces_cell_toc();
     
     var cell_toc_text = "# Table of Contents\n <p>";
-    var depth = 1;
-    var li;
-    $("#notebook").find(":header").map(function (i, h) {
-      var level = parseInt(h.tagName.slice(1), 10);
+    var depth = 1; //var depth = ol_depth(ol);
+    var li= ul;//yes, initialize li with ul! 
+    var all_headers= $("#notebook").find(":header");
+    var min_lvl=1, lbl_ary= [];
+    for(; min_lvl <= 6; min_lvl++){ if(all_headers.is('h'+min_lvl)){break;} }
+    for(var i= min_lvl; i <= 6; i++){ lbl_ary[i - min_lvl]= 0; }
+
+    //loop over all headers
+    all_headers.each(function (i, h) {
+      var level = parseInt(h.tagName.slice(1), 10) - min_lvl + 1;
       // skip below threshold
-      if (level > threshold) return;
+      if (level > threshold){ return; }
       // skip headings with no ID to link to
-      if (!h.id) return;
+      if (!h.id){ return; }
       // skip toc cell if present
-      if (h.id=="Table-of-Contents") return;
-      
-      //var depth = ol_depth(ol);
+      if (h.id=="Table-of-Contents"){ return; }
+      //If h had already a number, remove it
+      $(h).find(".toc-item-num").remove();
+      var num_str= incr_lbl(lbl_ary,level-1).join('.');// numbered heading labels
+      var num_lbl= $("<span/>").addClass("toc-item-num")
+            .text(num_str).append('&nbsp;').append('&nbsp;');
 
       // walk down levels
-      for (; depth < level; depth++) {
-        var new_ol = $("<ol/>");
-        new_ol.addClass("toc-item");
-        li.append(new_ol);
-        ol = new_ol;
+      for(var elm=li; depth < level; depth++) {
+          var new_ul = $("<ul/>").addClass("toc-item");
+          elm.append(new_ul);
+          elm= ul= new_ul;
       }
       // walk up levels
-      for (; depth > level; depth--) {
-          // up twice: the enclosing <ol> and the <li> it was  inserted in 
-          ol = ol.parent().parent();
+      for(; depth > level; depth--) {
+          // up twice: the enclosing <ol> and <li> it was inserted in
+          ul= ul.parent();
+          while(!ul.is('ul')){ ul= ul.parent(); }
       }
-      //
-      $(h).find(".toc-item-num").remove(); //If h had already a number, remove it
-      li=$("<li/>").append(make_link($(h)));
-      ol.append(li);
-      
 
+      // Create toc entry, append <li> tag to the current <ol>. Prepend numbered-labels to headings.
+      li=$("<li/>").append( make_link( $(h), num_lbl));
+      ul.append(li);
+      if( number_sections ){ $(h).prepend(num_lbl); }
 
-    // Add numerotation of sections if number_sections==true
-    // adapted from from http://stackoverflow.com/questions/5127017/automatic-numbering-of-headings-h1-h6-using-jquery
-    if (number_sections){
-      if(segments.length == level) {
-        // from Hn to another Hn, just increment the last segment
-        segments[level-1]++;
-      } else if(segments.length > level) {
-        // from Hn to Hn-x, slice off the last x segments, and increment the last of the remaining
-        segments = segments.slice(0, level);
-        segments[level-1]++;
-      } else if(segments.length < level) {
-        // from Hn to Hn+x, (should always be Hn+1, but some error checks anyway)
-        // add '0' (x-1) times, then a 1
-        var deltalevel = level-segments.length   
-        for(var i = 0; i < (deltalevel-1); i++) {
-          segments.push(0);
-        }
-        segments.push(1);
+      //toc_cell:
+      if(toc_cell) {
+          var tabs = function(level) {
+                var tabs = '';
+                for (var j = 0; j < level -1; j++) { 
+                  tabs += "\t";}
+                  return tabs}
+
+          var leves='<div class="lev'+level.toString()+'">'
+          var lnk=make_link($(h))
+          cell_toc_text += leves + $('<p>').append(lnk).html()+'</div>';
+          //workaround for https://github.com/jupyter/notebook/issues/699 as suggested by @jhamrick
+          lnk.on('click',function(){setTimeout(function(){console.log('clicked'); $.ajax()}, 100) }) 
       }
-      var num=$("<span/>").addClass("toc-item-num").text(segments.join(".")+" - ");
-      //$(h).find(".toc-item-num").remove(); //If h had already a number, remove it
-      $(h).prepend(num);
-}
-    //---------------------------
-//toc_cell:
-if(toc_cell) {
-    var tabs = function(level) {
-          var tabs = '';
-          for (var j = 0; j < level -1; j++) { 
-		    tabs += "\t";}
-            return tabs}
-
-    var leves='<div class="lev'+level.toString()+'">'
-    var lnk=make_link($(h))
-    cell_toc_text += leves + $('<p>').append(lnk).html()+'</div>';
-    lnk.on('click',function(){setTimeout(function(){console.log('clicked'); $.ajax()}, 100) })  //workaround for  https://github.com/jupyter/notebook/issues/699
-                                                                                        //as suggested by @jhamrick
-    }
-
     });
 
     if(toc_cell) {
@@ -352,23 +334,22 @@ if(toc_cell) {
          //IPython.notebook.to_markdown(toc_index);
          cell_toc.set_text(cell_toc_text); 
          cell_toc.render();
-};
-
+    };
 
     $(window).resize(function(){
-      $('#toc').css({maxHeight: $(window).height() - 200});
+        $('#toc').css({maxHeight: $(window).height() - 200});
     });
 
     $(window).trigger('resize');
-  };
+};
     
   var toggle_toc = function () {
     // toggle draw (first because of first-click behavior)
     $("#toc-wrapper").toggle({'complete':function(){
-		IPython.notebook.metadata.toc['toc_window_display']=$('#toc-wrapper').css('display')=='block';
-					} 
-		});
-     IPython.notebook.set_dirty();
+        IPython.notebook.metadata.toc['toc_window_display']=$('#toc-wrapper').css('display')=='block';
+      }
+    });
+    IPython.notebook.set_dirty();
     // recompute:
     rendering_toc_cell = false;
     table_of_contents();
@@ -407,32 +388,30 @@ if(toc_cell) {
                                                        // thus I rely on kernel_ready.Kernel to read the initial config 
                                                        // and render the first  table of contents
             read_config(); 
-	    table_of_contents(); 
-	    // render toc for each markdown cell modification
-	    //$([IPython.events]).on("rendered.MarkdownCell", table_of_contents);
-	    $([IPython.events]).on("rendered.MarkdownCell", function(){table_of_contents();});
+        table_of_contents(); 
+        // render toc for each markdown cell modification
+        //$([IPython.events]).on("rendered.MarkdownCell", table_of_contents);
+        $([IPython.events]).on("rendered.MarkdownCell", function(){table_of_contents();});
             console.log("toc2 initialized (via notebook_loaded)")
-	    extension_initialized=true	; // flag to indicate that initialization was done
+        extension_initialized=true  ; // flag to indicate that initialization was done
 })
 
     $([IPython.events]).on("kernel_ready.Kernel", function(){
-            if (!extension_initialized){
+        if (!extension_initialized){
             read_config(); 
-	    table_of_contents(); 
-	    // render toc for each markdown cell modification
-	    $([IPython.events]).on("rendered.MarkdownCell", function(){table_of_contents();});
+            table_of_contents(); 
+            // render toc for each markdown cell modification
+            $([IPython.events]).on("rendered.MarkdownCell", function(){table_of_contents();});
             console.log("toc2 initialized (via kernel_ready)")
-	}
-   });
+        }
+    });
 
   };
-
 
   return {
     load_ipython_extension : load_ipython_extension,
     toggle_toc : toggle_toc,
     table_of_contents : table_of_contents
-    
   };
 
 });

--- a/nbextensions/usability/toc2/presentation.md
+++ b/nbextensions/usability/toc2/presentation.md
@@ -1,7 +1,7 @@
 # Table of Contents (2)
 
 This is an update of "Table of Contents" extension, with the following new features:
-- The toc window can now be moved on screen. The position and states (that is 'collapsed' and 'hidden' states) are remembered (actually stored in the notebook's metadata) and restored on the next session.
+- The toc window can now be moved on screen. The position and states (that is 'collapsed' and 'hidden' states) are remembered (actually stored in the notebook's metadata) and restored on the next session. The toc window can also be resized as needed and the new size is restored on the newt session. 
 - Numerotation - The different headers in the notebook can be automatically numbered (with automatic update)
 - Toc cell - A "toc cell" can be created at top of the notebook and its contents automatically updated. This cell can be moved elsewhere in the notebook andd its position will be remembered and restored. 
 

--- a/nbextensions/usability/toc2/toc2.yaml
+++ b/nbextensions/usability/toc2/toc2.yaml
@@ -1,5 +1,5 @@
 Type: IPython Notebook Extension
-Name: Table of Contents (2)
+Name: Table of Contents (2) 
 Description: The ToC2 extension displays a floating (draggable) table of contents of the notebooks headers. Optionally, it also allows to automatically number all notebook's sections, and to add a table of Contents cell at the top of the notebook. 
 Link: README.md
 Icon: icon.png


### PR DESCRIPTION
This commit fixes some issues when resizing the toc window: 
- the text did not resized as the window and overflowed
- there was no possible scrolling
Now the text is reflowed according to the dimensions of the new window, overflow is avoided and a scroll bar appears when needed. 

This commit includes the modifications by @slonik-az in #472. Thus should be merged after this commit. 