### PR TITLE
Align toggle with base line of first row of heading cell

### DIFF
--- a/nbextensions/usability/collapsible_headings/main.css
+++ b/nbextensions/usability/collapsible_headings/main.css
@@ -36,7 +36,7 @@
 
 .collapsible_headings_toggle {
 	flex: 1;
-    align-self: center;
+    align-self: baseline;
 }
 
 /* bracket rules */


### PR DESCRIPTION
If the heading cell has more than one line (see example below) then the toggle is aligned vertically with the middle of the cell. I think the toggle should be aligned with the based line of the first line of the cell.

Example: markdown cell might have the contents
# Using stacking and pre-processing
Treat all log_feature and location data as high cardinality nominal categorical data and pre-process using ridge logistic regression.

Gives a lower score of log-loss: Training 0.6172, Validate 0.7066  
