### PR TITLE
Updates to `usability/collapsible_headings`:

### DIFF
--- a/nbextensions/usability/collapsible_headings/collapsible_headings.yaml
+++ b/nbextensions/usability/collapsible_headings/collapsible_headings.yaml
@@ -52,3 +52,7 @@ Parameters:
   description: Command-mode shortcut to uncollapse (expand) the selected heading cell
   input_type: hotkey
   default: right
+- name: collapsible_headings_shortcut_select
+  description: Command-mode shortcut to select all cells in the selected heading cell's section
+  input_type: hotkey
+  default: shift-right

--- a/nbextensions/usability/collapsible_headings/collapsible_headings.yaml
+++ b/nbextensions/usability/collapsible_headings/collapsible_headings.yaml
@@ -56,3 +56,7 @@ Parameters:
   description: Command-mode shortcut to select all cells in the selected heading cell's section
   input_type: hotkey
   default: shift-right
+- name: collapsible_headings_select_reveals
+  description: "By default, selecting a whole section also expands the section to reveal its last cell. Set this option to false to disable the expansion."
+  input_type: hotkey
+  default: shift-right

--- a/nbextensions/usability/collapsible_headings/collapsible_headings.yaml
+++ b/nbextensions/usability/collapsible_headings/collapsible_headings.yaml
@@ -36,6 +36,12 @@ Parameters:
   description: show Mathematica-style brackets around each collapsible section
   input_type: checkbox
   default: false
+- name: collapsible_headings_section_bracket_width
+  description: 'Width, in pixels, of the Mathematica-style brackets around sections'
+  input_type: number
+  min: 2
+  max: 20
+  default: 5
 - name: collapsible_headings_show_ellipsis
   description: show a gray bracketed ellipsis at the end of collapsed heading cells
   input_type: checkbox

--- a/nbextensions/usability/collapsible_headings/collapsible_headings.yaml
+++ b/nbextensions/usability/collapsible_headings/collapsible_headings.yaml
@@ -58,5 +58,5 @@ Parameters:
   default: shift-right
 - name: collapsible_headings_select_reveals
   description: "By default, selecting a whole section also expands the section to reveal its last cell. Set this option to false to disable the expansion."
-  input_type: hotkey
-  default: shift-right
+  input_type: checkbox
+  default: true

--- a/nbextensions/usability/collapsible_headings/main.css
+++ b/nbextensions/usability/collapsible_headings/main.css
@@ -73,13 +73,15 @@ div.cell {
   margin-left: 2px;
   width: 5px;
   border-color: #aaa;
+  border-left-color: transparent;
   border-style: solid;
-  border-width: 0 1px 0 0;
+  border-width: 0 1px 0 1px;
 }
 
 .chb div:hover,
 .chb .chb-hover {
     border-color: #000;
+    border-left-color: transparent;
 }
 
 .chb .chb-start {
@@ -93,7 +95,7 @@ div.cell {
 }
 
 .collapsible_headings_collapsed .chb .chb-start {
-  border-width: 5px 2px 2px 0;
+  border-width: 5px 2px 2px 4px;
 }
 
 /* ellipsis rules */

--- a/nbextensions/usability/collapsible_headings/main.css
+++ b/nbextensions/usability/collapsible_headings/main.css
@@ -77,6 +77,11 @@ div.cell {
   border-width: 0 1px 0 0;
 }
 
+.chb div:hover,
+.chb .chb-hover {
+    border-color: #000;
+}
+
 .chb .chb-start {
   border-top-width: 1px;
   margin-top: 2px;

--- a/nbextensions/usability/collapsible_headings/main.css
+++ b/nbextensions/usability/collapsible_headings/main.css
@@ -21,6 +21,15 @@
   line-height: 1.0;
 }
 
+.collapsible_headings_toggle.btn .h1,
+.collapsible_headings_toggle.btn .h2,
+.collapsible_headings_toggle.btn .h3,
+.collapsible_headings_toggle.btn .h4,
+.collapsible_headings_toggle.btn .h5,
+.collapsible_headings_toggle.btn .h6 {
+  margin-top: 0;
+}
+
 .collapsible_headings_toggle .fa:before {
 	transition: transform 400ms;
 

--- a/nbextensions/usability/collapsible_headings/main.js
+++ b/nbextensions/usability/collapsible_headings/main.js
@@ -115,7 +115,7 @@ define([
 		// Restrict the search to cells that are of the same level and lower
 		// than the currently selected cell by index.
 		var ref_cell = Jupyter.notebook.get_cell(index);
-		var pivot_level = get_cell_level(ref_cell) - 1;
+		var pivot_level = get_cell_level(ref_cell);
 		while (index > 0) {
 			index--;
 			var cell = Jupyter.notebook.get_cell(index);

--- a/nbextensions/usability/collapsible_headings/main.js
+++ b/nbextensions/usability/collapsible_headings/main.js
@@ -26,6 +26,7 @@ define([
 	var action_name_select; // set on registration
 	var toggle_closed_class; // set on config load
 	var toggle_open_class; // set on config load
+	var select_reveals = true; // used as a flag to prevent selecting a heading section from also opening it
 
 	if (Jupyter.version[0] < 3) {
 		console.log('[' + mod_name + '] This extension requires IPython/Jupyter >= 3.x');
@@ -197,15 +198,20 @@ define([
 				break;
 			}
 		}
+		select_reveals = false;
 		if (extend) {
 			var ank_ind = Jupyter.notebook.get_anchor_index();
 			if (ank_ind <= head_ind) {
 				// keep current anchor, extend to head
-				return Jupyter.notebook.select(tail_ind, false);
+				Jupyter.notebook.select(tail_ind, false);
+				select_reveals = true;
+				return;
 			}
 			else if (ank_ind >= tail_ind) {
 				// keep current anchor, extend to tail
-				return Jupyter.notebook.select(head_ind, false);
+				Jupyter.notebook.select(head_ind, false);
+				select_reveals = true;
+				return;
 			}
 			// head_ind < ank_ind < tail_ind i.e. anchor is inside section
 		}
@@ -213,6 +219,7 @@ define([
 		Jupyter.notebook.select(head_ind, true);
 		// don't move anchor, i.e. extend, to tail cell
 		Jupyter.notebook.select(tail_ind, false);
+		select_reveals = true;
 	}
 
 	/**
@@ -359,7 +366,9 @@ define([
 		// by cell click events, not by the notebook select method
 		var orig_notebook_select = notebook.Notebook.prototype.select;
 		notebook.Notebook.prototype.select = function (index, moveanchor) {
-			reveal_cell_by_index(index);
+			if (select_reveals) {
+				reveal_cell_by_index(index);
+			}
 			return orig_notebook_select.apply(this, arguments);
 		};
 

--- a/nbextensions/usability/collapsible_headings/main.js
+++ b/nbextensions/usability/collapsible_headings/main.js
@@ -178,7 +178,7 @@ define([
 	 * find the closest header cell to input cell
 	 */
 	function find_header_cell (cell, test_func) {
-		for (var index = cell.element.index(); index >= 0; index--) {
+		for (var index = Jupyter.notebook.find_cell_index(cell); index >= 0; index--) {
 			cell = Jupyter.notebook.get_cell(index);
 			if (is_heading(cell) && (test_func === undefined || test_func(cell))) {
 				return cell;
@@ -190,7 +190,7 @@ define([
 	function select_heading_section(head_cell, extend) {
 		var head_lvl = get_cell_level(head_cell);
 		var ncells = Jupyter.notebook.ncells();
-		var head_ind = head_cell.element.index();
+		var head_ind = Jupyter.notebook.find_cell_index(head_cell);
 		var tail_ind;
 		for (tail_ind = head_ind; tail_ind + 1 < ncells; tail_ind++) {
 			if (get_cell_level(Jupyter.notebook.get_cell(tail_ind + 1)) <= head_lvl) {
@@ -270,7 +270,7 @@ define([
 		var show = true;
 		if (cell !== undefined) {
 			cell = find_header_cell(cell);
-			index = cell.element.index() + 1;
+			index = Jupyter.notebook.find_cell_index(cell) + 1;
 			section_level = get_cell_level(cell);
 			show = cell.metadata.heading_collapsed !== true;
 		}
@@ -345,7 +345,7 @@ define([
 			else {
 				delete cell.metadata.heading_collapsed;
 			}
-			console.log('['+ mod_name + '] ' + (set_collapsed ? 'collapsed' : 'expanded') +' cell ' + cell.element.index());
+			console.log('['+ mod_name + '] ' + (set_collapsed ? 'collapsed' : 'expanded') +' cell ' + Jupyter.notebook.find_cell_index(cell));
 			update_collapsed_headings(params.collapsible_headings_show_section_brackets ? undefined : cell);
 			update_heading_cell_status(cell);
 		}
@@ -437,7 +437,7 @@ define([
 					else {
 						cell = find_header_cell(cell);
 						if (cell !== undefined) {
-							Jupyter.notebook.select(cell.element.index());
+							Jupyter.notebook.select(Jupyter.notebook.find_cell_index(cell));
 							cell.focus_cell();
 						}
 					}
@@ -457,7 +457,7 @@ define([
 					}
 					else {
 						var ncells = Jupyter.notebook.ncells();
-						for (var ii = cell.element.index(); ii < ncells; ii++) {
+						for (var ii = Jupyter.notebook.find_cell_index(cell); ii < ncells; ii++) {
 							cell = Jupyter.notebook.get_cell(ii);
 							if (is_heading(cell)) {
 								Jupyter.notebook.select(ii);
@@ -513,7 +513,7 @@ define([
 					});
 					if (is_heading(heading_cell)) {
 						toggle_heading(heading_cell, true);
-						Jupyter.notebook.select(heading_cell.element.index());
+						Jupyter.notebook.select(Jupyter.notebook.find_cell_index(heading_cell));
 					}
 				}
 			}]);
@@ -538,7 +538,7 @@ define([
 				cmd_shrts.add_shortcut(shrt, action_name_select);
 			}
 		}
-		
+
 		// bind to the create.Cell event to ensure that any newly-created cells are registered
 		events.on('create.Cell', function (evt, data) {
 			reveal_cell_by_index(data.index);

--- a/nbextensions/usability/collapsible_headings/main.js
+++ b/nbextensions/usability/collapsible_headings/main.js
@@ -278,6 +278,7 @@ define([
 			}
 			// adjust padding to fit in brackets
 			$('#notebook-container').css('padding-right', (16 + max_open * 7) + 'px');
+			$('.chb').css('right', '-' + (3 + max_open * 7) + 'px');
 		}
 	}
 
@@ -408,8 +409,6 @@ define([
 		// set css classes
 		toggle_open_class = params.collapsible_headings_toggle_open_icon || '';
 		toggle_closed_class = params.collapsible_headings_toggle_closed_icon || '';
-
-		// add css for 
 
 		// (Maybe) add a button to the toolbar
 		if (params.collapsible_headings_add_button) {

--- a/nbextensions/usability/collapsible_headings/main.js
+++ b/nbextensions/usability/collapsible_headings/main.js
@@ -429,7 +429,17 @@ define([
 	function register_new_actions () {
 		action_name_collapse = Jupyter.keyboard_manager.actions.register({
 				handler : function (env) {
-					toggle_heading(env.notebook.get_selected_cell(), true);
+					var cell = env.notebook.get_selected_cell();
+					if (is_heading(cell)) {
+						toggle_heading(cell, true);
+					}
+					else {
+						cell = find_header_cell(cell);
+						if (cell !== undefined) {
+							Jupyter.notebook.select(cell.element.index());
+							cell.focus_cell();
+						}
+					}
 				},
 				help : "Collapse the selected heading cell's section",
 				icon : toggle_closed_class,
@@ -440,7 +450,21 @@ define([
 
 		action_name_uncollapse = Jupyter.keyboard_manager.actions.register({
 				handler : function (env) {
-					toggle_heading(env.notebook.get_selected_cell(), false);
+					var cell = env.notebook.get_selected_cell();
+					if (is_heading(cell)) {
+						toggle_heading(cell, false);
+					}
+					else {
+						var ncells = Jupyter.notebook.ncells();
+						for (var ii = cell.element.index(); ii < ncells; ii++) {
+							cell = Jupyter.notebook.get_cell(ii);
+							if (is_heading(cell)) {
+								Jupyter.notebook.select(ii);
+								cell.focus_cell();
+								break;
+							}
+						}
+					}
 				},
 				help : "Un-collapse (expand) the selected heading cell's section",
 				icon : toggle_open_class,

--- a/nbextensions/usability/collapsible_headings/main.js
+++ b/nbextensions/usability/collapsible_headings/main.js
@@ -23,6 +23,7 @@ define([
 	var mod_name = 'collapsible_headings';
 	var action_name_collapse; // set on registration
 	var action_name_uncollapse; // set on registration
+	var action_name_select; // set on registration
 	var toggle_closed_class; // set on config load
 	var toggle_open_class; // set on config load
 
@@ -47,6 +48,7 @@ define([
 		collapsible_headings_use_shortcuts : true,
 		collapsible_headings_shortcut_collapse : 'left',
 		collapsible_headings_shortcut_uncollapse: 'right',
+		collapsible_headings_shortcut_select : 'shift-right',
 		collapsible_headings_show_section_brackets : false,
 		collapsible_headings_show_ellipsis: false
 	};
@@ -176,7 +178,6 @@ define([
 	 * find the closest header cell to input cell
 	 */
 	function find_header_cell (cell, test_func) {
-		var header_cell = cell;
 		for (var index = cell.element.index(); index >= 0; index--) {
 			cell = Jupyter.notebook.get_cell(index);
 			if (is_heading(cell) && (test_func === undefined || test_func(cell))) {
@@ -472,6 +473,19 @@ define([
 			},
 			'uncollapse_heading', mod_name
 		);
+
+		action_name_select = Jupyter.keyboard_manager.actions.register({
+				handler : function (env) {
+					var cell = env.notebook.get_selected_cell();
+					if (is_heading(cell)) {
+						select_heading_section(cell, true);
+					}
+				},
+				help : "Select all cells in the selected heading cell's section",
+				help_index: 'c3'
+			},
+			'select_heading_section', mod_name
+		);
 	}
 
 
@@ -517,6 +531,11 @@ define([
 			shrt = params.collapsible_headings_shortcut_uncollapse;
 			if (shrt) {
 				cmd_shrts.add_shortcut(shrt, action_name_uncollapse);
+			}
+
+			shrt = params.collapsible_headings_shortcut_select;
+			if (shrt) {
+				cmd_shrts.add_shortcut(shrt, action_name_select);
 			}
 		}
 		

--- a/nbextensions/usability/collapsible_headings/main.js
+++ b/nbextensions/usability/collapsible_headings/main.js
@@ -51,7 +51,8 @@ define([
 		collapsible_headings_shortcut_uncollapse: 'right',
 		collapsible_headings_shortcut_select : 'shift-right',
 		collapsible_headings_show_section_brackets : false,
-		collapsible_headings_show_ellipsis: false
+		collapsible_headings_show_ellipsis: false,
+		collapsible_headings_select_reveals: true
 	};
 
 	// function to update params with any specified in the server's config file
@@ -150,7 +151,7 @@ define([
 						.addClass('collapsible_headings_toggle')
 						.css('color', params.collapsible_headings_toggle_color)
 						.append('<div><i class="fa fa-fw"></i></div>')
-						.on('click', function () { toggle_heading(cell);})
+						.on('click', function () { toggle_heading(cell); })
 						.appendTo(cell.element.find('.input_prompt'));
 					if (params.collapsible_headings_make_toggle_controls_buttons) {
 						cht.addClass('btn btn-default');
@@ -198,7 +199,7 @@ define([
 				break;
 			}
 		}
-		select_reveals = false;
+		select_reveals = params.collapsible_headings_select_reveals;
 		if (extend) {
 			var ank_ind = Jupyter.notebook.get_anchor_index();
 			if (ank_ind <= head_ind) {
@@ -352,7 +353,7 @@ define([
 			else {
 				delete cell.metadata.heading_collapsed;
 			}
-			console.log('['+ mod_name + '] ' + (set_collapsed ? 'collapsed' : 'expanded') +' cell ' + Jupyter.notebook.find_cell_index(cell));
+			console.log('[' + mod_name + '] ' + (set_collapsed ? 'collapsed' : 'expanded') +' cell ' + Jupyter.notebook.find_cell_index(cell));
 			update_collapsed_headings(params.collapsible_headings_show_section_brackets ? undefined : cell);
 			update_heading_cell_status(cell);
 		}

--- a/nbextensions/usability/collapsible_headings/main.js
+++ b/nbextensions/usability/collapsible_headings/main.js
@@ -51,6 +51,7 @@ define([
 		collapsible_headings_shortcut_uncollapse: 'right',
 		collapsible_headings_shortcut_select : 'shift-right',
 		collapsible_headings_show_section_brackets : false,
+		collapsible_headings_section_bracket_width: 10,
 		collapsible_headings_show_ellipsis: false,
 		collapsible_headings_select_reveals: true
 	};
@@ -359,8 +360,13 @@ define([
 				brackets_open[ii].addClass('chb-end');
 			}
 			// adjust padding to fit in brackets
-			$('#notebook-container').css('padding-right', (16 + max_open * 7) + 'px');
-			$('.chb').css('right', '-' + (3 + max_open * 7) + 'px');
+			var bwidth = params.collapsible_headings_section_bracket_width;
+			var dwidth = max_open * (2 + bwidth);
+			$('#notebook-container').css('padding-right', (16 + dwidth) + 'px');
+			$('.chb')
+				.css('right', '-' + (3 + dwidth) + 'px')
+				.find('div')
+					.css('width', bwidth);
 		}
 	}
 

--- a/nbextensions/usability/collapsible_headings/readme.md
+++ b/nbextensions/usability/collapsible_headings/readme.md
@@ -15,7 +15,9 @@ status of headings, each of which can be enabled, disabled or configured from
 the nbextensions config page:
 
 * Command-mode keyboard shortcuts, (enabled by default, and set to left and
-  right arrow keys, but bindings are also configurable from the config page)
+  right arrow keys to collapse/expand sections, or go to the previous/next
+  heading, plus shift-right to select a heading cell's section).
+  Bindings are also configurable from the config page
 * A toggle control in the input prompt area of each heading cell (as seen in
   the screenshot below, enabled by default)
   * Configurable icons and icon color for the toggle control (by default, grey
@@ -23,8 +25,9 @@ the nbextensions config page:
   * The option to make the toggle control into a button (by default it's just a
     clickable icon)
 * Mathematica-style grouping brackets around each collapsible section on the
-  right of the notebook, clickable to toggle the relevant section (disabled by
-  default)
+  right of the notebook. Single-clicking a bracket will select all cells in the
+  section, while double-clicking the bracket toggles the section's
+  collpased/expanded status (disabled by default)
 * A gray bracketed ellipsis added to the end of each collapsed heading,
   indicating hidden content (disabled by default)
 * A toolbar button to collapse the nearest heading to the curently selected


### PR DESCRIPTION
New features:
 * Add an extra keyboard shortcut to select all cells in the selected heading's section
 * Add support for single-clicking Mathematica-style brackets to select the whole of the bracketed section
 * Add a configurable flag so that selecting a whole heading section doesn't also expand it
 * Make the collapse/uncollapse shortcuts also select the next/previous heading if one isn't currently selected
 * make bracket width configurable
 * add a hover state for brackets, as suggested by @Kevin-McIsaac

improvements:
 * alter css to give brackets mitred corners
 * reduce use of patches, relying instead on the `delete.Cell` and `rendered.MarkdownCell` events.
 * Add comments to explain why we still have to patch undelete and select
 * use `Jupyter.notebook.find_cell_index` to find cell indices, seems more future-proof
 * update readme

fixes:
 * bugfix in yaml
 * fix margins for button-style toggles, broken in 70473e6
 * restore accidentally-broken right-hand alignment of Mathematica-style brackets
 * fix persistence and icon-showing issues in github issue #482, which seem to be a result of variability in when callbacks are executed
 * bugfix reveal_cell_by_index, which wasn't opening level 6 headings
