### PR TITLE
Nbconvert template for collapsible_headings

### DIFF
--- a/templates/collapsible_headings.tpl
+++ b/templates/collapsible_headings.tpl
@@ -1,0 +1,9 @@
+{%- extends 'full.tpl' -%}
+
+{% block any_cell scoped %}
+{%- if cell.metadata.collapsed -%}
+{%- else -%}
+{{ super() }}
+{%- endif -%}
+{% endblock any_cell %}
+


### PR DESCRIPTION
Allow hiding collapsed cells in nbconvert.

@jcb91 : All collapsed cells need `cell.metadata.collapsed=true` with this template.
Alternatively, the existing `hide_input_output.tpl` could be used: 
```
{% block input_group -%}
{%- if cell.metadata.hide_input -%}
{%- else -%}
{{ super() }}
{%- endif -%}
{% endblock input_group %}

{% block output_group -%}
{%- if cell.metadata.hide_output -%}
{%- else -%}
{{ super() }}
{%- endif -%}
{% endblock output_group %}

```
Then `cell.metadata.hide_input` and `cell.metadata.hide_output` need to be set.