### PR TITLE
fix conflicting config following install…

### DIFF
--- a/configure_nbextensions.py
+++ b/configure_nbextensions.py
@@ -43,7 +43,7 @@ def update_config(config_file):
         print("Configuring %s" % config_file)
     make_backup(config_file)
 
-    new_config = "import os\nimport sys\nsys.path.append(os.path.join(r'{0:s}', 'extensions'))\nc = get_config()\nc.Exporter.template_path = [ '.', os.path.join(r'{0:s}', 'templates') ]".format(data_dir)
+    new_config = "import sys\nsys.path.append({0!r})".format(os.path.join(data_dir, 'extensions'))
     # add config
     with open(config_file, 'a+') as f:
         f.seek(0)


### PR DESCRIPTION
…
fixes #523
don't configure `Exporter.template_path` in python config, as it's already done in json, and doing both causes conflicts