### PR TITLE
Bugfix for `usability/collapsible_headings`…

### DIFF
--- a/nbextensions/usability/collapsible_headings/main.js
+++ b/nbextensions/usability/collapsible_headings/main.js
@@ -305,8 +305,7 @@ define([
 		var index = 0;
 		var section_level = 0;
 		var show = true;
-		if (cell !== undefined) {
-			cell = find_header_cell(cell);
+		if (cell !== undefined && (cell = find_header_cell(cell)) !== undefined) {
 			index = Jupyter.notebook.find_cell_index(cell) + 1;
 			section_level = get_cell_level(cell);
 			show = cell.metadata.heading_collapsed !== true;


### PR DESCRIPTION
…`find_heading_cell` can return `undefined`!
This was causing problems when trying to convert code cells to markdown cells in a notebook without heading cells - the blank cell contents would mean that the find_heading_cell call would throw an error, which somehow caused a new markdown cell to be inserted under the existing one - I think perhaps the deletion of the old cell only occurs after the insertion of the replacement succeeds?