### PR TITLE
remove old, unused configuration scripts

### DIFF
--- a/bld.bat
+++ b/bld.bat
@@ -1,2 +1,0 @@
-"%PYTHON%" setup.py install
-if errorlevel 1 exit 1

--- a/build.sh
+++ b/build.sh
@@ -1,1 +1,0 @@
-python setup.py install

--- a/jupyter_nbconvert_config.py
+++ b/jupyter_nbconvert_config.py
@@ -1,8 +1,0 @@
-from jupyter_core.paths import jupyter_config_dir, jupyter_data_dir
-import os
-import sys
-
-sys.path.append(os.path.join(jupyter_data_dir(), 'extensions'))
-
-c = get_config()
-c.Exporter.template_path = [ '.', os.path.join(jupyter_data_dir(), 'templates') ]

--- a/jupyter_notebook_config.py
+++ b/jupyter_notebook_config.py
@@ -1,9 +1,0 @@
-from jupyter_core.paths import jupyter_config_dir, jupyter_data_dir
-import os
-import sys
-
-sys.path.append(os.path.join(jupyter_data_dir(), 'extensions'))
-
-c = get_config()
-c.NotebookApp.extra_template_paths = [os.path.join(jupyter_data_dir(),'templates') ]
-


### PR DESCRIPTION
None of these scripts are actually used in any of our recommended installation methods anymore, so I think we should get rid of them, in favour of promoting pip/setup.py