### PR TITLE
Updates to config extension

### DIFF
--- a/extensions/nbextensions.py
+++ b/extensions/nbextensions.py
@@ -36,15 +36,12 @@ class NBExtensionHandler(IPythonHandler):
 
         # Build a list of extensions from YAML file description
         # containing at least the following entries:
-        #   Type          - identifier
-        #   Compatibility - compatible notebook version, e.g. '4.x'
-        #   Name          - unique name of the extension
-        #   Description   - short explanation of the extension
-        #   Main          - main file that is loaded, typically 'main.js'
+        #   Type - identifier, must be either 'IPython Notebook Extension' or 'Jupyter Notebook Extension'
+        #   Name - unique name of the extension
+        #   Main - relative path to main file that is loaded, typically 'main.js'
         #
         extension_list = []
-        required_keys = (
-            'Type', 'Compatibility', 'Name', 'Main', 'Description')
+        required_keys = ('Type', 'Name', 'Main')
 
         for ext_dir, yaml_filename in sorted(yaml_list):
             with open(os.path.join(ext_dir, yaml_filename), 'r') as stream:
@@ -59,11 +56,10 @@ class NBExtensionHandler(IPythonHandler):
                 continue
             if extension['Type'].strip() not in ['IPython Notebook Extension', 'Jupyter Notebook Extension']:
                 continue
-            compat = extension['Compatibility'].strip()
+            compat = extension.setdefault('Compatibility', '?.x').strip()
             if not compat.startswith(
                     notebook.__version__[:2]):
                 pass
-                # continue
 
             # generate URL to extension's main js file
             idx = ext_dir.find('nbextensions')

--- a/extensions/nbextensions.py
+++ b/extensions/nbextensions.py
@@ -37,11 +37,10 @@ class NBExtensionHandler(IPythonHandler):
         # Build a list of extensions from YAML file description
         # containing at least the following entries:
         #   Type - identifier, must be either 'IPython Notebook Extension' or 'Jupyter Notebook Extension'
-        #   Name - unique name of the extension
         #   Main - relative path to main file that is loaded, typically 'main.js'
         #
         extension_list = []
-        required_keys = ('Type', 'Name', 'Main')
+        required_keys = ('Type', 'Main')
 
         for ext_dir, yaml_filename in sorted(yaml_list):
             with open(os.path.join(ext_dir, yaml_filename), 'r') as stream:

--- a/nbextensions/config/main.js
+++ b/nbextensions/config/main.js
@@ -652,20 +652,22 @@ define([
 
             /**
              * Columns
-             * right prepends left in markup in order that it appears first
-             * when the columns are wrapped each onto a single line.
-             * The push and pull CSS classes are then used to get them to be
-             * left/right correctly when next to each other
              */
-            var col_right = $('<div>')
-                .addClass("col-xs-12 col-sm-4 col-sm-push-8 col-md-6 col-md-push-6")
-                .appendTo(ext_row);
             var col_left = $('<div/>')
-                .addClass("col-xs-12 col-sm-8 col-sm-pull-4 col-md-6 col-md-pull-6")
+                .addClass('col-xs-12')
                 .appendTo(ext_row);
 
             // Icon
             if (extension.Icon) {
+                col_left
+                    .addClass('col-sm-8 col-sm-pull-4 col-md-6 col-md-pull-6');
+                // right precedes left in markup, so that it appears first when
+                // the columns are wrapped each onto a single line.
+                // The push and pull CSS classes are then used to get them to
+                // be left/right correctly when next to each other
+                var col_right = $('<div>')
+                    .addClass('col-xs-12 col-sm-4 col-sm-push-8 col-md-6 col-md-push-6')
+                    .insertBefore(col_left);
                 $('<div/>')
                     .addClass('nbext-icon')
                     .append(
@@ -725,7 +727,7 @@ define([
                     extension.Parameters[ii].section = extension.Section;
                 }
                 $('<div/>')
-                    .addClass('panel panel-default nbext-params')
+                    .addClass('panel panel-default nbext-params col-xs-12')
                     .append(
                         $('<div/>')
                             .addClass('panel-heading')
@@ -734,7 +736,7 @@ define([
                     .append(
                         build_params_ui(extension.Parameters)
                     )
-                    .appendTo(col_left);
+                    .appendTo(ext_row);
             }
         }
         catch (err) {

--- a/nbextensions/config/main.js
+++ b/nbextensions/config/main.js
@@ -869,7 +869,8 @@ define([
         for (i = 0; i < extension_list.length; i++) {
             extension = extension_list[i];
             extension.main_url = get_ext_url(extension_list[i]);
-            extension.Section = extension.Section || 'notebook';
+            extension.Section = (extension.Section || 'notebook').toString();
+            extension.Name = (extension.Name || (extension.Section + ':' + extension.main_url)).toString();
             // extension *is* configurable
             delete unconfigurable_enabled_extensions[extension.Section][extension.main_url];
         }

--- a/nbextensions/config/main.js
+++ b/nbextensions/config/main.js
@@ -429,7 +429,7 @@ define([
         var is_absolute = /^(f|ht)tps?:\/\//i.test(url);
         if (is_absolute || (utils.splitext(url)[1] !== '.md')) {
             // provide a link only
-            var desc = $('#' + extension.id + ' .nbext-desc');
+            var desc = extension.ui.find('.nbext-desc');
             var link = desc.find('.nbext-readme-more-link');
             if (link.length === 0) {
                 desc.append(' ');
@@ -633,7 +633,6 @@ define([
      */
     function build_extension_ui (extension) {
         var ext_row = $('<div/>')
-            .attr('id', extension.id)
             .data('extension', extension)
             .addClass('row nbext-ext-row');
 
@@ -832,7 +831,6 @@ define([
                 $('.nbext-showhide-incompat').show();
             }
             extension.selector_link = $('<a/>')
-                .attr('href', '#' + extension.id)
                 .data('extension', extension)
                 .html(extension.Name)
                 .prepend(

--- a/nbextensions/config/main.js
+++ b/nbextensions/config/main.js
@@ -25,8 +25,8 @@ define([
     quickhelp,
     rendermd,
     kse_comp
-){
-    "use strict";
+) {
+    'use strict';
 
     var base_url = utils.get_body_data('baseUrl');
     var first_load_done = false; // flag used to not push history on first load
@@ -115,10 +115,10 @@ define([
      */
     function set_config_active (extension, state) {
         state = state === undefined ? true : state;
-        console.log('nbext', state ? ' enable:' : 'disable:' , extension.Name );
+        console.log('nbext', state ? ' enable:' : 'disable:', extension.Name);
         var to_load = {};
         to_load[extension.main_url] = (state ? true : null);
-        configs[extension.Section].update({"load_extensions": to_load});
+        configs[extension.Section].update({load_extensions: to_load});
     }
 
     /**
@@ -162,7 +162,7 @@ define([
             case 'hotkey':
                 return input.find('.hotkey').data('pre-humanized');
             case 'list':
-                var val=[];
+                var val = [];
                 input.find('.nbext-list-element').children().not('a').each(
                     function () {
                         // "this" is the current child element of input in the loop
@@ -193,7 +193,7 @@ define([
                 var ul = input.children('ul');
                 ul.empty();
                 var list_element_param = input.data('list_element_param');
-                for (var ii=0; ii < new_value.length; ii++) {
+                for (var ii = 0; ii < new_value.length; ii++) {
                     var list_element_input = build_param_input(list_element_param);
                     list_element_input.on('change', handle_input);
                     set_input_value(list_element_input, new_value[ii]);
@@ -269,8 +269,8 @@ define([
                 input.append($('<div class="input-group-btn"/>').append(
                     $('<div class="btn-group"/>').append(
                         $('<a/>', {
-                            type:'button',
-                            class: "btn btn-primary",
+                            type: 'button',
+                            class: 'btn btn-primary',
                             text: 'Change'
                         }).on('click', function() {
                             var description = 'Change ' +
@@ -358,7 +358,7 @@ define([
         input.data('section', param.section);
         var non_form_control_input_types = ['checkbox', 'list', 'hotkey'];
         if (non_form_control_input_types.indexOf(input_type) < 0) {
-          input.addClass("form-control");
+            input.addClass('form-control');
         }
         return input;
     }
@@ -712,7 +712,7 @@ define([
             }
 
             // Compatibility
-            var compat_txt = extension.Compatibility || "?.x";
+            var compat_txt = extension.Compatibility || '?.x';
             var compat_idx = compat_txt.toLowerCase().indexOf(
                 Jupyter.version.substring(0, 2) + 'x');
             if (!extension.is_compatible) {
@@ -799,7 +799,7 @@ define([
             .prependTo('.nbext-showhide-incompat');
 
         nbext_config_page.show_header();
-        events.trigger("resize-header.Page");
+        events.trigger('resize-header.Page');
 
         var config_promises = [];
         for (var section in configs) {
@@ -857,7 +857,7 @@ define([
         // get list of extensions from body data supplied by the python backend
         var extension_list = $('body').data('extension-list') || [];
 
-        var container = $("#site > .container");
+        var container = $('#site > .container');
 
         var selector = $('.nbext-selector');
         var cols = selector.find('ul');
@@ -873,10 +873,10 @@ define([
 
         // fill the columns with nav links
         var col_length = Math.ceil(extension_list.length / cols.length);
-        for (var i in extension_list) {
+        for (i = 0; i < extension_list.length; i++) {
             var extension = extension_list[i];
-            console.log("nbext extension:", extension.Name);
-            extension.is_compatible = (extension.Compatibility || "?.x").toLowerCase().indexOf(
+            console.log('nbext extension:', extension.Name);
+            extension.is_compatible = (extension.Compatibility || '?.x').toLowerCase().indexOf(
                 Jupyter.version.substring(0, 2) + 'x') >= 0;
             extension.main_url = get_ext_url(extension);
             extensions_dict[extension.main_url] = extension;
@@ -935,11 +935,11 @@ define([
      * @param name filename
      */
     function add_css (name) {
-        var link = document.createElement("link");
-        link.type = "text/css";
-        link.rel = "stylesheet";
+        var link = document.createElement('link');
+        link.type = 'text/css';
+        link.rel = 'stylesheet';
         link.href = require.toUrl(name);
-        document.getElementsByTagName("head")[0].appendChild(link);
+        document.getElementsByTagName('head')[0].appendChild(link);
     }
 
     return {

--- a/nbextensions/config/main.js
+++ b/nbextensions/config/main.js
@@ -115,7 +115,7 @@ define([
      */
     function set_config_active (extension, state) {
         state = state === undefined ? true : state;
-        console.log('nbext', state ? ' enable:' : 'disable:', extension.Name);
+        console.log('Notebook extension "' + extension.Name + '"', state ? 'enabled' : 'disabled');
         var to_load = {};
         to_load[extension.main_url] = (state ? true : null);
         configs[extension.Section].update({load_extensions: to_load});
@@ -227,8 +227,9 @@ define([
         // get param name by cutting off prefix
         var configkey = input.attr('id').substring(param_id_prefix.length);
         var configval = get_input_value(input);
-        console.log(configkey, '->', configval);
-        conf_dot_update(configs[input.data('section')], configkey, configval);
+        var configsection = input.data('section');
+        console.log(configsection + '.' + configkey, '->', configval);
+        conf_dot_update(configs[configsection], configkey, configval);
         return configval;
     }
 
@@ -907,7 +908,7 @@ define([
         for (i = 0; i < extension_list.length; i++) {
             extension = extension_list[i];
             extensions_dict[extension.main_url] = extension;
-            console.log('nbext extension:', extension.Name);
+            console.log('Notebook extension "' + extension.Name + '" found');
 
             extension.is_compatible = (extension.Compatibility || '?.x').toLowerCase().indexOf(
                 Jupyter.version.substring(0, 2) + 'x') >= 0;

--- a/nbextensions/config/main.js
+++ b/nbextensions/config/main.js
@@ -635,7 +635,7 @@ define([
         var ext_row = $('<div/>')
             .attr('id', extension.id)
             .data('extension', extension)
-            .addClass('row nbext-row nbext-ext-row');
+            .addClass('row nbext-ext-row');
 
         try {
             /**
@@ -807,32 +807,14 @@ define([
         var selector = $('.nbext-selector');
         var cols = selector.find('ul');
 
-        // (try to) sort extensions alphabetically
-        try {
-            extension_list.sort(function (a, b) {
-                var an = (a.Name || '').toLowerCase();
-                var bn = (b.Name || '').toLowerCase();
-                if (an < bn) return -1;
-                if (an > bn) return 1;
-                return 0;
-            });
-        }
-        catch (err) {
-            console.error('nbext: error loading extension json data!');
-            $('<div/>')
-                .addClass('alert alert-danger')
-                .css('margin', '2em')
-                .append(
-                    $('<h3/>')
-                        .text('error loading extension json data!')
-                ).append(
-                    $('<p/>')
-                        .text('It might be worth checking your server logs, or the browser javascript console.')
-                )
-                .appendTo(container);
-            // no more to be done without an extension list
-            return;
-        }
+        // sort extensions alphabetically
+        extension_list.sort(function (a, b) {
+            var an = (a.Name || '').toLowerCase();
+            var bn = (b.Name || '').toLowerCase();
+            if (an < bn) return -1;
+            if (an > bn) return 1;
+            return 0;
+        });
 
         // fill the columns with nav links
         var col_length = Math.ceil(extension_list.length / cols.length);

--- a/nbextensions/config/main.js
+++ b/nbextensions/config/main.js
@@ -138,9 +138,9 @@ define([
     function set_buttons_active (extension, state) {
         state = (state === true);
 
-        $('a[href=#' + extension.id + '] > .nbext-active-toggle').toggleClass('nbext-activated', state);
+        extension.selector_link.find('.nbext-active-toggle').toggleClass('nbext-activated', state);
 
-        var btns = $('#' + extension.id).find('.nbext-activate-btns').children();
+        var btns = $(extension.ui).find('.nbext-activate-btns').children();
         btns.eq(0)
             .prop('disabled', state)
             .toggleClass('btn-default disabled', state)
@@ -503,13 +503,13 @@ define([
                 .css('display', 'none')
                 .insertBefore('.nbext-readme');
 
-            var ext_active = $('a[href=#' + extension.id + '] > .nbext-active-toggle').hasClass('nbext-activated');
+            var ext_active = extension.selector_link.find('.nbext-active-toggle').hasClass('nbext-activated');
             set_buttons_active(extension, ext_active);
         }
 
         $('.nbext-selector li')
             .removeClass('active');
-        $('a[href=#' + extension.id + ']').closest('li').addClass('active');
+        extension.selector_link.closest('li').addClass('active');
 
         $('.nbext-ext-row')
             .not(extension.ui)
@@ -536,8 +536,7 @@ define([
             complete: function () {
                 // scroll to ensure at least title is visible
                 var site = $('#site');
-                var ext_ui = site.find(a.attr('href'));
-                var title = ext_ui.children('h3:first');
+                var title = extension.ui.children('h3:first');
                 var adjust = (title.offset().top - site.offset().top) + (2 * title.outerHeight(true) - site.innerHeight());
                 if (adjust > 0) {
                     site.animate({scrollTop: site.scrollTop() + adjust});
@@ -850,18 +849,17 @@ define([
                 // reveal the checkbox since we've found an incompatible nbext
                 $('.nbext-showhide-incompat').show();
             }
+            extension.selector_link = $('<a/>')
+                .attr('href', '#' + extension.id)
+                .data('extension', extension)
+                .html(extension.Name)
+                .prepend(
+                    $('<i>')
+                        .addClass('fa fa-fw nbext-active-toggle')
+                );
             $('<li/>')
                 .toggleClass('nbext-incompatible', !extension.is_compatible)
-                .append(
-                    $('<a/>')
-                        .attr('href', '#' + extension.id)
-                        .data('extension', extension)
-                        .html(extension.Name)
-                        .prepend(
-                            $('<i>')
-                                .addClass('fa fa-fw nbext-active-toggle')
-                        )
-                )
+                .append(extension.selector_link)
                 .appendTo(cols[Math.floor(i / col_length)]);
 
             var ext_active = false;


### PR DESCRIPTION
Function:
* add entries for nbextensions which are enabled, but not associated with a yaml file. This should make fixing problems like #505 a little easier
* relax requirements for nbextension yaml descriptor files, removing absolute requirement for `Compatibility` and `Description` keys
* Use `window.history` instead of hashes to record which extension is selected.

UI
* Only have two columns when there is an icon to put into the right one. Otherwise, it'd just be empty anyway
* Make parameters full-width, rather than sitting in the left column

Code cleanup:
* treat extensions as more object-like
* remove redundant css classes, exception-catching
* some style-guide fixes
* Don't export functions which aren't used outside this module.