### PR TITLE
bugfix non-matching default parameters in `collapsible_headings`…

### DIFF
--- a/nbextensions/usability/collapsible_headings/collapsible_headings.yaml
+++ b/nbextensions/usability/collapsible_headings/collapsible_headings.yaml
@@ -17,7 +17,7 @@ Parameters:
 - name: collapsible_headings_toggle_color
   description: Color for the toggle control icon
   input_type: color
-  default: '#aaa'
+  default: '#aaaaaa'
 - name: collapsible_headings_toggle_closed_icon
   description: font-awesome class for the toggle control icon on collapsed headings
   default: fa-caret-right
@@ -31,7 +31,7 @@ Parameters:
 - name: collapsible_headings_size_toggle_controls_by_level
   description: Adjust the size of the toggle controls to match their heading levels
   input_type: checkbox
-  default: false
+  default: true
 - name: collapsible_headings_show_section_brackets
   description: show Mathematica-style brackets around each collapsible section
   input_type: checkbox
@@ -40,8 +40,8 @@ Parameters:
   description: 'Width, in pixels, of the Mathematica-style brackets around sections'
   input_type: number
   min: 2
-  max: 20
-  default: 5
+  max: 100
+  default: 10
 - name: collapsible_headings_show_ellipsis
   description: show a gray bracketed ellipsis at the end of collapsed heading cells
   input_type: checkbox

--- a/nbextensions/usability/collapsible_headings/main.js
+++ b/nbextensions/usability/collapsible_headings/main.js
@@ -47,15 +47,15 @@ define([
 		collapsible_headings_size_toggle_controls_by_level : true,
 		collapsible_headings_toggle_open_icon : 'fa-caret-down',
 		collapsible_headings_toggle_closed_icon : 'fa-caret-right',
-		collapsible_headings_toggle_color : '#aaa',
+		collapsible_headings_toggle_color : '#aaaaaa',
 		collapsible_headings_use_shortcuts : true,
 		collapsible_headings_shortcut_collapse : 'left',
 		collapsible_headings_shortcut_uncollapse: 'right',
 		collapsible_headings_shortcut_select : 'shift-right',
 		collapsible_headings_show_section_brackets : false,
-		collapsible_headings_section_bracket_width: 10,
-		collapsible_headings_show_ellipsis: false,
-		collapsible_headings_select_reveals: true
+		collapsible_headings_section_bracket_width : 10,
+		collapsible_headings_show_ellipsis : true,
+		collapsible_headings_select_reveals : true
 	};
 
 	// function to update params with any specified in the server's config file


### PR DESCRIPTION
… js and yaml files disagreed about defaults, leading to confusing behaviour on config page. Also, it seems that config colors can't be specified as 3-char hex codes, but need to be 6 in order to set html5 input correctly.