### PR TITLE
Fix broken image link in runtools readme.

### DIFF
--- a/nbextensions/usability/runtools/readme.md
+++ b/nbextensions/usability/runtools/readme.md
@@ -30,7 +30,7 @@ Description
 ===========
 
 The *runtools* extension adds a button to turn on/off a floating toolbar:   
-![](runtools.png)
+![](icon.png)
 
 This adds Code execution buttons:   
 ![](runtools_execute.png)


### PR DESCRIPTION
Image was removed in db90c41e (#331), but it was basically the same as the icon, so just use that instead.