### PR TITLE
Change links in toc_cell to original ids

### DIFF
--- a/nbextensions/usability/toc2/main.js
+++ b/nbextensions/usability/toc2/main.js
@@ -66,6 +66,8 @@ define(["require", "jquery", "base/js/namespace",  'services/config',
       return ary.slice(0, h_idx+1);
   }
 
+
+
   var make_link = function (h, num_lbl) {
     var a = $("<a/>");
     a.attr("href", '#' + h.attr('id'));
@@ -80,6 +82,20 @@ define(["require", "jquery", "base/js/namespace",  'services/config',
     //console.log("h",h.children)
     return a;
   };
+
+
+  var make_link_originalid = function (h, num_lbl) {
+    var a = $("<a/>");
+    a.attr("href", '#' + h.attr('saveid'));
+    // get the text *excluding* the link text, whatever it may be
+    var hclone = h.clone();
+    if( num_lbl ){ hclone.prepend(num_lbl); }
+    hclone.children().last().remove(); // remove the last child (that is the automatic anchor)
+    hclone.find("a[name]").remove();   //remove all named anchors
+    a.html(hclone.html());
+    a.on('click',function(){setTimeout(function(){ $.ajax()}, 100) }) //workaround for  https://github.com/jupyter/notebook/issues/699
+    return a;
+}
 
   var ol_depth = function (element) {
     // get depth of nested ol
@@ -362,7 +378,7 @@ var table_of_contents = function () {
                   return tabs}
 
           var leves='<div class="lev'+level.toString()+'">'
-          var lnk=make_link($(h))
+          var lnk=make_link_originalid($(h))
           cell_toc_text += leves + $('<p>').append(lnk).html()+'</div>';
           //workaround for https://github.com/jupyter/notebook/issues/699 as suggested by @jhamrick
           lnk.on('click',function(){setTimeout(function(){console.log('clicked'); $.ajax()}, 100) }) 
@@ -377,7 +393,7 @@ var table_of_contents = function () {
     };
 
     $(window).resize(function(){
-        $('#toc').css({maxHeight: $(window).height() - 200});
+        $('#toc').css({maxHeight: $(window).height() - 100});
     });
 
     $(window).trigger('resize');


### PR DESCRIPTION
This is a small modification to address part of #551 

The links in toc_cell, the cell with toc at the bottom of the notebook were incorrect since they link to anchors constructed as the original id+number of section, in order to get a unique id. But since these anchors only exist in the live notebook, they do not survive to nbconvert conversion. At this time, the best I can see is to link to the original ids instead for the toc_cell -- but with the problem that we may have same anchors for sections with the same heading. The unique anchors are preserved within the toc window itself. 

----
I will investigate possible solutions for preserving/restoring section numberings + unique ids in the toc_cell. This shall involve writing a preprocessor (I think that invoking a js file through nodejs could be a way to do it).. Will investigate, but later... 