### PR TITLE
This extension adds the ability to split a cell vertically in a notebook.

### DIFF
--- a/nbextensions/usability/splitcell/readme.md
+++ b/nbextensions/usability/splitcell/readme.md
@@ -1,0 +1,3 @@
+## Split Cells for Jupyter/Ipython Notebooks
+
+Enter command mode (esc), use shift-s to toggle the current cell to either a split cell or full width.

--- a/nbextensions/usability/splitcell/splitcell.js
+++ b/nbextensions/usability/splitcell/splitcell.js
@@ -1,0 +1,96 @@
+// Allow for split cells in jupyter notebooks
+
+define([
+	'base/js/namespace',
+    'services/config',
+    'base/js/utils'
+    ], function(IPython, configmod, utils){
+	"use strict";
+
+	//create config object to load paramters
+	var base_url = utils.get_body_data("baseUrl");
+	var config = new configmod.ConfigSection('notebook', {base_url: base_url});
+
+	//define default config parameter values
+	var params = {
+		toggle_cell_style_keybinding : 'shift-s'
+	};
+
+	//updates default params with any specified in the server's config
+	var update_params = function(){
+		for (var key in params){
+			if (config.data.hasOwnProperty(key)){
+				params[key] = config.data[key];
+			}
+		}
+	};
+
+	console.log('updated params')
+
+	config.loaded.then(function(){
+		// update defaults
+		update_params();
+
+		//register actions with ActionHandler instance
+		var prefix = 'auto';
+		var name = 'toggle-cell-style';
+		var action = {
+			icon : 'fa-style-o',
+			help : 'Toggle split/centered cell style',
+			help_index : 'eb',
+			id : 'split_cells',
+			handler : toggle_cell_style
+					};
+
+		var action_full_name = IPython.keyboard_manager.actions.register(action, name, prefix);
+
+		//define keyboard shortucts
+		var command_mode_shortcuts = {};
+		command_mode_shortcuts[params.toggle_cell_style_keybinding] =  action_full_name;
+
+		//register keyboard shortucts with keyboard_manager
+		IPython.notebook.keyboard_manager.command_shortcuts.add_shortcuts(command_mode_shortcuts);
+	});
+
+
+	var toggle_cell_style = function(){
+		var cell = IPython.notebook.get_selected_cell();
+		if (!("cell_style" in cell.metadata)){cell.metadata.cell_style = 'split';}
+		else if (cell.metadata.cell_style == 'center'){cell.metadata.cell_style = 'split';}
+		else {cell.metadata.cell_style = 'center';}
+
+		update_cell_style_element(cell);
+	}
+
+	var get_cell_style_html = function(cell_style){
+		console.log(cell_style)
+        if (cell_style == "split") 
+            {return "float:left; width:50%;";}
+        return "width:100%;";
+    	};
+
+    var update_cell_style_element = function(cell){
+    	var cell_style_html = get_cell_style_html(cell.metadata.cell_style);
+    	cell.element.attr('style', cell_style_html);
+    	}
+
+    // On Load lets set the cell styles correctly
+	var cells = IPython.notebook.get_cells();
+	var ncells = IPython.notebook.ncells();
+
+    for (var i=0; i<ncells; i++){
+    	var cell = cells[i];
+    	if ("cell_style" in cell.metadata){
+    		update_cell_style_element(cell, cell.metadata.cell_style)
+    	};
+   	 };
+
+
+	var load_extension = function() {
+		config.load();
+		};
+
+	return {
+		load_ipython_extension : load_extension
+		};
+});

--- a/nbextensions/usability/splitcell/splitcell.yaml
+++ b/nbextensions/usability/splitcell/splitcell.yaml
@@ -1,0 +1,6 @@
+Type: IPython Notebook Extension
+Name: splitcell
+Description: Enable split cells notebook
+Main: splitcell.js
+Compatibility: Jupyter (4.x)
+

--- a/nbextensions/usability/splitcell/splitcell.yaml
+++ b/nbextensions/usability/splitcell/splitcell.yaml
@@ -1,6 +1,6 @@
 Type: IPython Notebook Extension
-Name: splitcell
-Description: Enable split cells notebook
+Name: Split Cells Notebook
+Description: Enable split cells in Jupyter notebooks
 Main: splitcell.js
 Compatibility: Jupyter (4.x)
 


### PR DESCRIPTION
This shows the idea, in this extension you can currently only toggle the split cell using shift-s in command mode. I haven't added a button yet. The information is stored in the cell metadata. 


<img width="1280" alt="3f97874c-f93d-11e5-9f3c-7efe97d7dac3" src="https://cloud.githubusercontent.com/assets/884424/14452701/419742b2-0045-11e6-8960-71a3aeaf7b26.png">
