### PR TITLE
Fix rerendering of equations

### DIFF
--- a/nbextensions/usability/equation-numbering/info.yaml
+++ b/nbextensions/usability/equation-numbering/info.yaml
@@ -5,8 +5,3 @@ Link: readme.md
 Icon: icon.png
 Main: main.js
 Compatibility: 4.x
-Parameters:
-- name: equation_numbering_rerender
-  description: Regenerate math equations after resetting equation numbering
-  input_type: checkbox
-  default: true

--- a/nbextensions/usability/equation-numbering/main.js
+++ b/nbextensions/usability/equation-numbering/main.js
@@ -7,24 +7,9 @@ define([
     'require',
     'notebook/js/textcell',
     'base/js/utils',
-    'services/config'
-],   function(IPython, $, require, textcell, utils, configmod) {
+],   function(IPython, $, require, textcell, utils) {
     "use strict";
 
-    var rerender_on_reset = true;
-    var base_url = utils.get_body_data("baseUrl");
-    var config = new configmod.ConfigSection('notebook', {base_url: base_url});
-
-    /**
-     * Get option from config
-     */
-    config.loaded.then(function() {
-        if (config.data.hasOwnProperty('equation_numbering_rerender') ) {
-            if (typeof(config.data.equation_numbering_rerender) === "boolean") {
-                rerender_on_reset = config.data.equation_numbering_rerender;
-            }
-        }
-    });
     var load_ipython_extension = function() {
         IPython.toolbar.add_buttons_group([
             {
@@ -33,14 +18,10 @@ define([
                 icon: 'fa-sort-numeric-asc',
                 callback: function () {
                     MathJax.Hub.Queue(
-                        ["resetEquationNumbers", MathJax.InputJax.TeX]
+                        ["resetEquationNumbers", MathJax.InputJax.TeX],
+                        ["PreProcess", MathJax.Hub],
+                        ["Reprocess", MathJax.Hub]
                     );
-                    if (rerender_on_reset === true) {
-                        MathJax.Hub.Queue(
-                            ["PreProcess", MathJax.Hub],
-                            ["Reprocess", MathJax.Hub]
-                        );
-                    }
                     $('#reset_numbering').blur();
                 }
             }
@@ -48,7 +29,6 @@ define([
         MathJax.Hub.Config({
           TeX: { equationNumbers: { autoNumber: "AMS" } }
         });
-        config.load();
     };
 
     return {

--- a/nbextensions/usability/equation-numbering/main.js
+++ b/nbextensions/usability/equation-numbering/main.js
@@ -32,9 +32,14 @@ define([
                 label: 'Reset equation numbering',
                 icon: 'fa-sort-numeric-asc',
                 callback: function () {
-                    MathJax.Extension['TeX/AMSmath'].startNumber = 0;
+                    MathJax.Hub.Queue(
+                        ["resetEquationNumbers", MathJax.InputJax.TeX]
+                    );
                     if (rerender_on_reset === true) {
-                        MathJax.Hub.Queue(["Reprocess", MathJax.Hub]);
+                        MathJax.Hub.Queue(
+                            ["PreProcess", MathJax.Hub],
+                            ["Reprocess", MathJax.Hub]
+                        );
                     }
                     $('#reset_numbering').blur();
                 }

--- a/nbextensions/usability/equation-numbering/readme.md
+++ b/nbextensions/usability/equation-numbering/readme.md
@@ -26,6 +26,9 @@ MathJax.Hub.Config({
 
 Equation numbers are reset and math equations rerendered using this code: 
 ```Javascript
-MathJax.Extension['TeX/AMSmath'].startNumber = 0;
-MathJax.Hub.Queue(["Reprocess",MathJax.Hub]);
+MathJax.Hub.Queue(
+  ["resetEquationNumbers", MathJax.InputJax.TeX],
+  ["PreProcess", MathJax.Hub],
+  ["Reprocess", MathJax.Hub]
+);
 ```


### PR DESCRIPTION
Previously this extension had difficulties, when a markdown cell with an equation with a label was rendered twice. To correctly re-render the cell in this case the following procedure is recommended 
```Javascript
MathJax.Hub.Queue(
  ["resetEquationNumbers", MathJax.InputJax.TeX],
  ["PreProcess", MathJax.Hub],
  ["Reprocess", MathJax.Hub]
);
```
(see section *Reset Automatic Equation Numbering* of http://docs.mathjax.org/en/latest/advanced/typeset.html).

This approach also makes the configuration option 'equation_numbering_rerender' unnecessary, since now always all mathjax elements will be re-rendered when the icon is clicked. 