### PR TITLE
only attempt to use typo_dict if it's defined

### DIFF
--- a/nbextensions/usability/spellchecker/main.js
+++ b/nbextensions/usability/spellchecker/main.js
@@ -89,7 +89,7 @@ define([
 						// strip leading and trailing single quotes
 						var word = stream.current().replace(/(^')|('$)/g, '');
 						// we don't consider a set of digits as a word to spellcheck
-						if (!word.match(/^\d+$/) && !typo_dict.check(word)) {
+						if (!word.match(/^\d+$/) && (typo_dict !== undefined) && !typo_dict.check(word)) {
 							return 'spell-error';
 						}
 					}


### PR DESCRIPTION
otherwise the errors thrown in codemirror mode will break markdown cells almost entirely, as described in second part of #640 