### PR TITLE
Update Scratchpad

### DIFF
--- a/nbextensions/usability/scratchpad/README.md
+++ b/nbextensions/usability/scratchpad/README.md
@@ -3,8 +3,7 @@
 Adds a scratchpad cell to Jupyter notebook.
 This is a cell in which you can execute code against the current kernel without modifying the notebook document.
 
-The scratchpad can be toggled by clicking the icon in the bottom-right,
-or via the keyboard shortcut `Ctrl-B`.
+Scratchpad cells can be executed using `Shift-Enter` (other shortcuts are appled to the notebook document). The scratchpad can be toggled by clicking the icon in the bottom-right, or via the keyboard shortcut `Ctrl-B`.
 
 ![demo](demo.gif)
 

--- a/nbextensions/usability/scratchpad/main.js
+++ b/nbextensions/usability/scratchpad/main.js
@@ -79,12 +79,12 @@ define(['require'], function (require) {
     this.close_button.show();
     this.cell.element.show();
     this.cell.focus_editor();
-    $("#notebook-container").css('margin-left', 0);
+    //$("#notebook-container").css('margin-left', 0);
   };
 
   Scratchpad.prototype.collapse = function () {
     this.collapsed = true;
-    $("#notebook-container").css('margin-left', 'auto');
+    //$("#notebook-container").css('margin-left', 'auto');
     this.element.animate({
       height: 0,
     }, 100);


### PR DESCRIPTION
Just commented two lines in scratchpad main.js in order to remove lest-margin modifications. So doing, the Scratchpad can be used nicely with toc2. This address #654. Hope it does not have side-effects.

Also added a hint in `README` to indicate that scratchpad cell can be executed via `Shift-Enter`.